### PR TITLE
Add external VLESS user routing control

### DIFF
--- a/app/commander/commander.go
+++ b/app/commander/commander.go
@@ -23,13 +23,23 @@ type Commander struct {
 	ohm      outbound.Manager
 	tag      string
 	listen   string
+	maxRecv  int
+	maxSend  int
 }
 
 // NewCommander creates a new Commander based on the given config.
 func NewCommander(ctx context.Context, config *Config) (*Commander, error) {
+	if config.MaxReceiveMessageSize < 0 {
+		return nil, errors.New("Commander max receive message size must not be negative")
+	}
+	if config.MaxSendMessageSize < 0 {
+		return nil, errors.New("Commander max send message size must not be negative")
+	}
 	c := &Commander{
-		tag:    config.Tag,
-		listen: config.Listen,
+		tag:     config.Tag,
+		listen:  config.Listen,
+		maxRecv: int(config.MaxReceiveMessageSize),
+		maxSend: int(config.MaxSendMessageSize),
 	}
 
 	common.Must(core.RequireFeatures(ctx, func(om outbound.Manager) {
@@ -63,14 +73,22 @@ func (c *Commander) Type() interface{} {
 // Start implements common.Runnable.
 func (c *Commander) Start() error {
 	c.Lock()
-	c.server = grpc.NewServer()
+	var serverOptions []grpc.ServerOption
+	if c.maxRecv > 0 {
+		serverOptions = append(serverOptions, grpc.MaxRecvMsgSize(c.maxRecv))
+	}
+	if c.maxSend > 0 {
+		serverOptions = append(serverOptions, grpc.MaxSendMsgSize(c.maxSend))
+	}
+	server := grpc.NewServer(serverOptions...)
+	c.server = server
 	for _, service := range c.services {
-		service.Register(c.server)
+		service.Register(server)
 	}
 	c.Unlock()
 
 	listen := func(listener net.Listener) {
-		if err := c.server.Serve(listener); err != nil {
+		if err := server.Serve(listener); err != nil {
 			errors.LogErrorInner(context.Background(), err, "failed to start grpc server")
 		}
 	}

--- a/app/commander/commander_test.go
+++ b/app/commander/commander_test.go
@@ -1,0 +1,17 @@
+package commander
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewCommanderRejectsNegativeMessageLimits(t *testing.T) {
+	for _, config := range []*Config{
+		{MaxReceiveMessageSize: -1},
+		{MaxSendMessageSize: -1},
+	} {
+		if _, err := NewCommander(context.Background(), config); err == nil {
+			t.Fatalf("negative gRPC message limit was accepted: %+v", config)
+		}
+	}
+}

--- a/app/commander/config.pb.go
+++ b/app/commander/config.pb.go
@@ -31,9 +31,12 @@ type Config struct {
 	Listen string `protobuf:"bytes,3,opt,name=listen,proto3" json:"listen,omitempty"`
 	// Services that supported by this server. All services must implement Service
 	// interface.
-	Service       []*serial.TypedMessage `protobuf:"bytes,2,rep,name=service,proto3" json:"service,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Service []*serial.TypedMessage `protobuf:"bytes,2,rep,name=service,proto3" json:"service,omitempty"`
+	// Optional gRPC message limits in bytes. Zero keeps the gRPC defaults.
+	MaxReceiveMessageSize int32 `protobuf:"varint,4,opt,name=max_receive_message_size,json=maxReceiveMessageSize,proto3" json:"max_receive_message_size,omitempty"`
+	MaxSendMessageSize    int32 `protobuf:"varint,5,opt,name=max_send_message_size,json=maxSendMessageSize,proto3" json:"max_send_message_size,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
@@ -87,6 +90,20 @@ func (x *Config) GetService() []*serial.TypedMessage {
 	return nil
 }
 
+func (x *Config) GetMaxReceiveMessageSize() int32 {
+	if x != nil {
+		return x.MaxReceiveMessageSize
+	}
+	return 0
+}
+
+func (x *Config) GetMaxSendMessageSize() int32 {
+	if x != nil {
+		return x.MaxSendMessageSize
+	}
+	return 0
+}
+
 // ReflectionConfig is the placeholder config for ReflectionService.
 type ReflectionConfig struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -128,11 +145,13 @@ var File_app_commander_config_proto protoreflect.FileDescriptor
 
 const file_app_commander_config_proto_rawDesc = "" +
 	"\n" +
-	"\x1aapp/commander/config.proto\x12\x12xray.app.commander\x1a!common/serial/typed_message.proto\"n\n" +
+	"\x1aapp/commander/config.proto\x12\x12xray.app.commander\x1a!common/serial/typed_message.proto\"\xda\x01\n" +
 	"\x06Config\x12\x10\n" +
 	"\x03tag\x18\x01 \x01(\tR\x03tag\x12\x16\n" +
 	"\x06listen\x18\x03 \x01(\tR\x06listen\x12:\n" +
-	"\aservice\x18\x02 \x03(\v2 .xray.common.serial.TypedMessageR\aservice\"\x12\n" +
+	"\aservice\x18\x02 \x03(\v2 .xray.common.serial.TypedMessageR\aservice\x127\n" +
+	"\x18max_receive_message_size\x18\x04 \x01(\x05R\x15maxReceiveMessageSize\x121\n" +
+	"\x15max_send_message_size\x18\x05 \x01(\x05R\x12maxSendMessageSize\"\x12\n" +
 	"\x10ReflectionConfigBX\n" +
 	"\x16com.xray.app.commanderP\x01Z'github.com/xtls/xray-core/app/commander\xaa\x02\x12Xray.App.Commanderb\x06proto3"
 

--- a/app/commander/config.proto
+++ b/app/commander/config.proto
@@ -19,6 +19,10 @@ message Config {
   // Services that supported by this server. All services must implement Service
   // interface.
   repeated xray.common.serial.TypedMessage service = 2;
+
+  // Optional gRPC message limits in bytes. Zero keeps the gRPC defaults.
+  int32 max_receive_message_size = 4;
+  int32 max_send_message_size = 5;
 }
 
 // ReflectionConfig is the placeholder config for ReflectionService.

--- a/app/router/balancing.go
+++ b/app/router/balancing.go
@@ -136,7 +136,12 @@ func (b *Balancer) SelectOutbounds() ([]string, error) {
 
 // GetPrincipleTarget implements routing.BalancerPrincipleTarget
 func (r *Router) GetPrincipleTarget(tag string) ([]string, error) {
-	if b, ok := r.balancers[tag]; ok {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.state == nil {
+		return nil, ErrRuleSetUnavailable
+	}
+	if b, ok := r.state.balancers[tag]; ok {
 		if s, ok := b.strategy.(BalancingPrincipleTarget); ok {
 			candidates, err := b.SelectOutbounds()
 			if err != nil {
@@ -151,7 +156,12 @@ func (r *Router) GetPrincipleTarget(tag string) ([]string, error) {
 
 // SetOverrideTarget implements routing.BalancerOverrider
 func (r *Router) SetOverrideTarget(tag, target string) error {
-	if b, ok := r.balancers[tag]; ok {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.state == nil {
+		return ErrRuleSetUnavailable
+	}
+	if b, ok := r.state.balancers[tag]; ok {
 		b.override.Put(target)
 		return nil
 	}
@@ -160,7 +170,12 @@ func (r *Router) SetOverrideTarget(tag, target string) error {
 
 // GetOverrideTarget implements routing.BalancerOverrider
 func (r *Router) GetOverrideTarget(tag string) (string, error) {
-	if b, ok := r.balancers[tag]; ok {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.state == nil {
+		return "", ErrRuleSetUnavailable
+	}
+	if b, ok := r.state.balancers[tag]; ok {
 		return b.override.Get(), nil
 	}
 	return "", errors.New("cannot find tag")

--- a/app/router/balancing_override.go
+++ b/app/router/balancing_override.go
@@ -7,8 +7,14 @@ import (
 )
 
 func (r *Router) OverrideBalancer(balancer string, target string) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.state == nil {
+		return ErrRuleSetUnavailable
+	}
+
 	var b *Balancer
-	for tag, bl := range r.balancers {
+	for tag, bl := range r.state.balancers {
 		if tag == balancer {
 			b = bl
 			break

--- a/app/router/command/command.go
+++ b/app/router/command/command.go
@@ -2,20 +2,31 @@ package command
 
 import (
 	"context"
+	stderrors "errors"
 	"time"
 
+	approuter "github.com/xtls/xray-core/app/router"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/features/stats"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // routingServer is an implementation of RoutingService.
 type routingServer struct {
 	router       routing.Router
 	routingStats stats.Channel
+}
+
+type ruleSetManager interface {
+	GetRuleSet() (approuter.RuleSetVersion, *serial.TypedMessage, error)
+	GetRuleSetVersion() (approuter.RuleSetVersion, error)
+	ReplaceRuleSet(approuter.RuleSetVersion, *serial.TypedMessage) (approuter.RuleSetVersion, error)
 }
 
 func (s *routingServer) GetBalancerInfo(ctx context.Context, request *GetBalancerInfoRequest) (*GetBalancerInfoResponse, error) {
@@ -79,6 +90,83 @@ func (s *routingServer) ListRule(ctx context.Context, request *ListRuleRequest) 
 		return response, nil
 	}
 	return nil, errors.New("unsupported router implementation")
+}
+
+func (s *routingServer) GetRuleSet(_ context.Context, request *GetRuleSetRequest) (*GetRuleSetResponse, error) {
+	manager, ok := s.router.(ruleSetManager)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "router does not support versioned rule sets")
+	}
+	var (
+		version approuter.RuleSetVersion
+		config  *serial.TypedMessage
+		err     error
+	)
+	if request != nil && request.IncludeConfig {
+		version, config, err = manager.GetRuleSet()
+	} else {
+		version, err = manager.GetRuleSetVersion()
+	}
+	if err != nil {
+		return nil, status.Error(codes.FailedPrecondition, err.Error())
+	}
+	response := &GetRuleSetResponse{
+		Version: &RuleSetVersion{
+			InstanceId: version.InstanceID,
+			Generation: version.Generation,
+		},
+	}
+	if request != nil && request.IncludeConfig {
+		response.Config = config
+	}
+	return response, nil
+}
+
+func (s *routingServer) ReplaceRuleSet(_ context.Context, request *ReplaceRuleSetRequest) (*ReplaceRuleSetResponse, error) {
+	manager, ok := s.router.(ruleSetManager)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "router does not support versioned rule sets")
+	}
+	if request == nil || request.ExpectedVersion == nil {
+		return nil, status.Error(codes.InvalidArgument, "expected_version is required")
+	}
+	if request.ExpectedVersion.InstanceId == "" {
+		return nil, status.Error(codes.InvalidArgument, "expected_version.instance_id is required")
+	}
+	if request.ExpectedVersion.Generation == 0 {
+		return nil, status.Error(codes.InvalidArgument, "expected_version.generation is required")
+	}
+	if request.Config == nil {
+		return nil, status.Error(codes.InvalidArgument, "config is required")
+	}
+
+	version, err := manager.ReplaceRuleSet(approuter.RuleSetVersion{
+		InstanceID: request.ExpectedVersion.InstanceId,
+		Generation: request.ExpectedVersion.Generation,
+	}, request.Config)
+	if err != nil {
+		return nil, ruleSetStatusError(err)
+	}
+	return &ReplaceRuleSetResponse{
+		Version: &RuleSetVersion{
+			InstanceId: version.InstanceID,
+			Generation: version.Generation,
+		},
+	}, nil
+}
+
+func ruleSetStatusError(err error) error {
+	switch {
+	case stderrors.Is(err, approuter.ErrRuleSetGenerationConflict):
+		return status.Error(codes.Aborted, err.Error())
+	case stderrors.Is(err, approuter.ErrRuleSetInstanceMismatch),
+		stderrors.Is(err, approuter.ErrRuleSetUnavailable):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case stderrors.Is(err, approuter.ErrRuleSetInvalidVersion):
+		return status.Error(codes.InvalidArgument, err.Error())
+	default:
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
 }
 
 // NewRoutingServer creates a statistics service with statistics manager.

--- a/app/router/command/command.pb.go
+++ b/app/router/command/command.pb.go
@@ -927,6 +927,252 @@ func (x *ListRuleResponse) GetRules() []*ListRuleItem {
 	return nil
 }
 
+type RuleSetVersion struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	InstanceId    string                 `protobuf:"bytes,1,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	Generation    uint64                 `protobuf:"varint,2,opt,name=generation,proto3" json:"generation,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RuleSetVersion) Reset() {
+	*x = RuleSetVersion{}
+	mi := &file_app_router_command_command_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RuleSetVersion) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RuleSetVersion) ProtoMessage() {}
+
+func (x *RuleSetVersion) ProtoReflect() protoreflect.Message {
+	mi := &file_app_router_command_command_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RuleSetVersion.ProtoReflect.Descriptor instead.
+func (*RuleSetVersion) Descriptor() ([]byte, []int) {
+	return file_app_router_command_command_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *RuleSetVersion) GetInstanceId() string {
+	if x != nil {
+		return x.InstanceId
+	}
+	return ""
+}
+
+func (x *RuleSetVersion) GetGeneration() uint64 {
+	if x != nil {
+		return x.Generation
+	}
+	return 0
+}
+
+type GetRuleSetRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Controllers that already own desired state can request only the version
+	// and avoid transferring a potentially large routing config.
+	IncludeConfig bool `protobuf:"varint,1,opt,name=include_config,json=includeConfig,proto3" json:"include_config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRuleSetRequest) Reset() {
+	*x = GetRuleSetRequest{}
+	mi := &file_app_router_command_command_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRuleSetRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRuleSetRequest) ProtoMessage() {}
+
+func (x *GetRuleSetRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_app_router_command_command_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRuleSetRequest.ProtoReflect.Descriptor instead.
+func (*GetRuleSetRequest) Descriptor() ([]byte, []int) {
+	return file_app_router_command_command_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *GetRuleSetRequest) GetIncludeConfig() bool {
+	if x != nil {
+		return x.IncludeConfig
+	}
+	return false
+}
+
+type GetRuleSetResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Version       *RuleSetVersion        `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	Config        *serial.TypedMessage   `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRuleSetResponse) Reset() {
+	*x = GetRuleSetResponse{}
+	mi := &file_app_router_command_command_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRuleSetResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRuleSetResponse) ProtoMessage() {}
+
+func (x *GetRuleSetResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_app_router_command_command_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRuleSetResponse.ProtoReflect.Descriptor instead.
+func (*GetRuleSetResponse) Descriptor() ([]byte, []int) {
+	return file_app_router_command_command_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *GetRuleSetResponse) GetVersion() *RuleSetVersion {
+	if x != nil {
+		return x.Version
+	}
+	return nil
+}
+
+func (x *GetRuleSetResponse) GetConfig() *serial.TypedMessage {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+type ReplaceRuleSetRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ExpectedVersion *RuleSetVersion        `protobuf:"bytes,1,opt,name=expected_version,json=expectedVersion,proto3" json:"expected_version,omitempty"`
+	Config          *serial.TypedMessage   `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ReplaceRuleSetRequest) Reset() {
+	*x = ReplaceRuleSetRequest{}
+	mi := &file_app_router_command_command_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReplaceRuleSetRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReplaceRuleSetRequest) ProtoMessage() {}
+
+func (x *ReplaceRuleSetRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_app_router_command_command_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReplaceRuleSetRequest.ProtoReflect.Descriptor instead.
+func (*ReplaceRuleSetRequest) Descriptor() ([]byte, []int) {
+	return file_app_router_command_command_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *ReplaceRuleSetRequest) GetExpectedVersion() *RuleSetVersion {
+	if x != nil {
+		return x.ExpectedVersion
+	}
+	return nil
+}
+
+func (x *ReplaceRuleSetRequest) GetConfig() *serial.TypedMessage {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+type ReplaceRuleSetResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Version       *RuleSetVersion        `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReplaceRuleSetResponse) Reset() {
+	*x = ReplaceRuleSetResponse{}
+	mi := &file_app_router_command_command_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReplaceRuleSetResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReplaceRuleSetResponse) ProtoMessage() {}
+
+func (x *ReplaceRuleSetResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_app_router_command_command_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReplaceRuleSetResponse.ProtoReflect.Descriptor instead.
+func (*ReplaceRuleSetResponse) Descriptor() ([]byte, []int) {
+	return file_app_router_command_command_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *ReplaceRuleSetResponse) GetVersion() *RuleSetVersion {
+	if x != nil {
+		return x.Version
+	}
+	return nil
+}
+
 type Config struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -935,7 +1181,7 @@ type Config struct {
 
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_app_router_command_command_proto_msgTypes[17]
+	mi := &file_app_router_command_command_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -947,7 +1193,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_app_router_command_command_proto_msgTypes[17]
+	mi := &file_app_router_command_command_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -960,7 +1206,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_app_router_command_command_proto_rawDescGZIP(), []int{17}
+	return file_app_router_command_command_proto_rawDescGZIP(), []int{22}
 }
 
 var File_app_router_command_command_proto protoreflect.FileDescriptor
@@ -1031,8 +1277,24 @@ const file_app_router_command_command_proto_rawDesc = "" +
 	"\x03tag\x18\x01 \x01(\tR\x03tag\x12\x18\n" +
 	"\aruleTag\x18\x02 \x01(\tR\aruleTag\"O\n" +
 	"\x10ListRuleResponse\x12;\n" +
-	"\x05rules\x18\x01 \x03(\v2%.xray.app.router.command.ListRuleItemR\x05rules\"\b\n" +
-	"\x06Config2\xa2\x06\n" +
+	"\x05rules\x18\x01 \x03(\v2%.xray.app.router.command.ListRuleItemR\x05rules\"Q\n" +
+	"\x0eRuleSetVersion\x12\x1f\n" +
+	"\vinstance_id\x18\x01 \x01(\tR\n" +
+	"instanceId\x12\x1e\n" +
+	"\n" +
+	"generation\x18\x02 \x01(\x04R\n" +
+	"generation\":\n" +
+	"\x11GetRuleSetRequest\x12%\n" +
+	"\x0einclude_config\x18\x01 \x01(\bR\rincludeConfig\"\x91\x01\n" +
+	"\x12GetRuleSetResponse\x12A\n" +
+	"\aversion\x18\x01 \x01(\v2'.xray.app.router.command.RuleSetVersionR\aversion\x128\n" +
+	"\x06config\x18\x02 \x01(\v2 .xray.common.serial.TypedMessageR\x06config\"\xa5\x01\n" +
+	"\x15ReplaceRuleSetRequest\x12R\n" +
+	"\x10expected_version\x18\x01 \x01(\v2'.xray.app.router.command.RuleSetVersionR\x0fexpectedVersion\x128\n" +
+	"\x06config\x18\x02 \x01(\v2 .xray.common.serial.TypedMessageR\x06config\"[\n" +
+	"\x16ReplaceRuleSetResponse\x12A\n" +
+	"\aversion\x18\x01 \x01(\v2'.xray.app.router.command.RuleSetVersionR\aversion\"\b\n" +
+	"\x06Config2\x80\b\n" +
 	"\x0eRoutingService\x12{\n" +
 	"\x15SubscribeRoutingStats\x125.xray.app.router.command.SubscribeRoutingStatsRequest\x1a'.xray.app.router.command.RoutingContext\"\x000\x01\x12a\n" +
 	"\tTestRoute\x12).xray.app.router.command.TestRouteRequest\x1a'.xray.app.router.command.RoutingContext\"\x00\x12v\n" +
@@ -1041,7 +1303,10 @@ const file_app_router_command_command_proto_rawDesc = "" +
 	"\aAddRule\x12'.xray.app.router.command.AddRuleRequest\x1a(.xray.app.router.command.AddRuleResponse\"\x00\x12g\n" +
 	"\n" +
 	"RemoveRule\x12*.xray.app.router.command.RemoveRuleRequest\x1a+.xray.app.router.command.RemoveRuleResponse\"\x00\x12a\n" +
-	"\bListRule\x12(.xray.app.router.command.ListRuleRequest\x1a).xray.app.router.command.ListRuleResponse\"\x00Bg\n" +
+	"\bListRule\x12(.xray.app.router.command.ListRuleRequest\x1a).xray.app.router.command.ListRuleResponse\"\x00\x12g\n" +
+	"\n" +
+	"GetRuleSet\x12*.xray.app.router.command.GetRuleSetRequest\x1a+.xray.app.router.command.GetRuleSetResponse\"\x00\x12s\n" +
+	"\x0eReplaceRuleSet\x12..xray.app.router.command.ReplaceRuleSetRequest\x1a/.xray.app.router.command.ReplaceRuleSetResponse\"\x00Bg\n" +
 	"\x1bcom.xray.app.router.commandP\x01Z,github.com/xtls/xray-core/app/router/command\xaa\x02\x17Xray.App.Router.Commandb\x06proto3"
 
 var (
@@ -1056,7 +1321,7 @@ func file_app_router_command_command_proto_rawDescGZIP() []byte {
 	return file_app_router_command_command_proto_rawDescData
 }
 
-var file_app_router_command_command_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_app_router_command_command_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_app_router_command_command_proto_goTypes = []any{
 	(*RoutingContext)(nil),                 // 0: xray.app.router.command.RoutingContext
 	(*SubscribeRoutingStatsRequest)(nil),   // 1: xray.app.router.command.SubscribeRoutingStatsRequest
@@ -1075,39 +1340,53 @@ var file_app_router_command_command_proto_goTypes = []any{
 	(*ListRuleRequest)(nil),                // 14: xray.app.router.command.ListRuleRequest
 	(*ListRuleItem)(nil),                   // 15: xray.app.router.command.ListRuleItem
 	(*ListRuleResponse)(nil),               // 16: xray.app.router.command.ListRuleResponse
-	(*Config)(nil),                         // 17: xray.app.router.command.Config
-	nil,                                    // 18: xray.app.router.command.RoutingContext.AttributesEntry
-	(net.Network)(0),                       // 19: xray.common.net.Network
-	(*serial.TypedMessage)(nil),            // 20: xray.common.serial.TypedMessage
+	(*RuleSetVersion)(nil),                 // 17: xray.app.router.command.RuleSetVersion
+	(*GetRuleSetRequest)(nil),              // 18: xray.app.router.command.GetRuleSetRequest
+	(*GetRuleSetResponse)(nil),             // 19: xray.app.router.command.GetRuleSetResponse
+	(*ReplaceRuleSetRequest)(nil),          // 20: xray.app.router.command.ReplaceRuleSetRequest
+	(*ReplaceRuleSetResponse)(nil),         // 21: xray.app.router.command.ReplaceRuleSetResponse
+	(*Config)(nil),                         // 22: xray.app.router.command.Config
+	nil,                                    // 23: xray.app.router.command.RoutingContext.AttributesEntry
+	(net.Network)(0),                       // 24: xray.common.net.Network
+	(*serial.TypedMessage)(nil),            // 25: xray.common.serial.TypedMessage
 }
 var file_app_router_command_command_proto_depIdxs = []int32{
-	19, // 0: xray.app.router.command.RoutingContext.Network:type_name -> xray.common.net.Network
-	18, // 1: xray.app.router.command.RoutingContext.Attributes:type_name -> xray.app.router.command.RoutingContext.AttributesEntry
+	24, // 0: xray.app.router.command.RoutingContext.Network:type_name -> xray.common.net.Network
+	23, // 1: xray.app.router.command.RoutingContext.Attributes:type_name -> xray.app.router.command.RoutingContext.AttributesEntry
 	0,  // 2: xray.app.router.command.TestRouteRequest.RoutingContext:type_name -> xray.app.router.command.RoutingContext
 	4,  // 3: xray.app.router.command.BalancerMsg.override:type_name -> xray.app.router.command.OverrideInfo
 	3,  // 4: xray.app.router.command.BalancerMsg.principle_target:type_name -> xray.app.router.command.PrincipleTargetInfo
 	5,  // 5: xray.app.router.command.GetBalancerInfoResponse.balancer:type_name -> xray.app.router.command.BalancerMsg
-	20, // 6: xray.app.router.command.AddRuleRequest.config:type_name -> xray.common.serial.TypedMessage
+	25, // 6: xray.app.router.command.AddRuleRequest.config:type_name -> xray.common.serial.TypedMessage
 	15, // 7: xray.app.router.command.ListRuleResponse.rules:type_name -> xray.app.router.command.ListRuleItem
-	1,  // 8: xray.app.router.command.RoutingService.SubscribeRoutingStats:input_type -> xray.app.router.command.SubscribeRoutingStatsRequest
-	2,  // 9: xray.app.router.command.RoutingService.TestRoute:input_type -> xray.app.router.command.TestRouteRequest
-	6,  // 10: xray.app.router.command.RoutingService.GetBalancerInfo:input_type -> xray.app.router.command.GetBalancerInfoRequest
-	8,  // 11: xray.app.router.command.RoutingService.OverrideBalancerTarget:input_type -> xray.app.router.command.OverrideBalancerTargetRequest
-	10, // 12: xray.app.router.command.RoutingService.AddRule:input_type -> xray.app.router.command.AddRuleRequest
-	12, // 13: xray.app.router.command.RoutingService.RemoveRule:input_type -> xray.app.router.command.RemoveRuleRequest
-	14, // 14: xray.app.router.command.RoutingService.ListRule:input_type -> xray.app.router.command.ListRuleRequest
-	0,  // 15: xray.app.router.command.RoutingService.SubscribeRoutingStats:output_type -> xray.app.router.command.RoutingContext
-	0,  // 16: xray.app.router.command.RoutingService.TestRoute:output_type -> xray.app.router.command.RoutingContext
-	7,  // 17: xray.app.router.command.RoutingService.GetBalancerInfo:output_type -> xray.app.router.command.GetBalancerInfoResponse
-	9,  // 18: xray.app.router.command.RoutingService.OverrideBalancerTarget:output_type -> xray.app.router.command.OverrideBalancerTargetResponse
-	11, // 19: xray.app.router.command.RoutingService.AddRule:output_type -> xray.app.router.command.AddRuleResponse
-	13, // 20: xray.app.router.command.RoutingService.RemoveRule:output_type -> xray.app.router.command.RemoveRuleResponse
-	16, // 21: xray.app.router.command.RoutingService.ListRule:output_type -> xray.app.router.command.ListRuleResponse
-	15, // [15:22] is the sub-list for method output_type
-	8,  // [8:15] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	17, // 8: xray.app.router.command.GetRuleSetResponse.version:type_name -> xray.app.router.command.RuleSetVersion
+	25, // 9: xray.app.router.command.GetRuleSetResponse.config:type_name -> xray.common.serial.TypedMessage
+	17, // 10: xray.app.router.command.ReplaceRuleSetRequest.expected_version:type_name -> xray.app.router.command.RuleSetVersion
+	25, // 11: xray.app.router.command.ReplaceRuleSetRequest.config:type_name -> xray.common.serial.TypedMessage
+	17, // 12: xray.app.router.command.ReplaceRuleSetResponse.version:type_name -> xray.app.router.command.RuleSetVersion
+	1,  // 13: xray.app.router.command.RoutingService.SubscribeRoutingStats:input_type -> xray.app.router.command.SubscribeRoutingStatsRequest
+	2,  // 14: xray.app.router.command.RoutingService.TestRoute:input_type -> xray.app.router.command.TestRouteRequest
+	6,  // 15: xray.app.router.command.RoutingService.GetBalancerInfo:input_type -> xray.app.router.command.GetBalancerInfoRequest
+	8,  // 16: xray.app.router.command.RoutingService.OverrideBalancerTarget:input_type -> xray.app.router.command.OverrideBalancerTargetRequest
+	10, // 17: xray.app.router.command.RoutingService.AddRule:input_type -> xray.app.router.command.AddRuleRequest
+	12, // 18: xray.app.router.command.RoutingService.RemoveRule:input_type -> xray.app.router.command.RemoveRuleRequest
+	14, // 19: xray.app.router.command.RoutingService.ListRule:input_type -> xray.app.router.command.ListRuleRequest
+	18, // 20: xray.app.router.command.RoutingService.GetRuleSet:input_type -> xray.app.router.command.GetRuleSetRequest
+	20, // 21: xray.app.router.command.RoutingService.ReplaceRuleSet:input_type -> xray.app.router.command.ReplaceRuleSetRequest
+	0,  // 22: xray.app.router.command.RoutingService.SubscribeRoutingStats:output_type -> xray.app.router.command.RoutingContext
+	0,  // 23: xray.app.router.command.RoutingService.TestRoute:output_type -> xray.app.router.command.RoutingContext
+	7,  // 24: xray.app.router.command.RoutingService.GetBalancerInfo:output_type -> xray.app.router.command.GetBalancerInfoResponse
+	9,  // 25: xray.app.router.command.RoutingService.OverrideBalancerTarget:output_type -> xray.app.router.command.OverrideBalancerTargetResponse
+	11, // 26: xray.app.router.command.RoutingService.AddRule:output_type -> xray.app.router.command.AddRuleResponse
+	13, // 27: xray.app.router.command.RoutingService.RemoveRule:output_type -> xray.app.router.command.RemoveRuleResponse
+	16, // 28: xray.app.router.command.RoutingService.ListRule:output_type -> xray.app.router.command.ListRuleResponse
+	19, // 29: xray.app.router.command.RoutingService.GetRuleSet:output_type -> xray.app.router.command.GetRuleSetResponse
+	21, // 30: xray.app.router.command.RoutingService.ReplaceRuleSet:output_type -> xray.app.router.command.ReplaceRuleSetResponse
+	22, // [22:31] is the sub-list for method output_type
+	13, // [13:22] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_app_router_command_command_proto_init() }
@@ -1121,7 +1400,7 @@ func file_app_router_command_command_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_app_router_command_command_proto_rawDesc), len(file_app_router_command_command_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   19,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/app/router/command/command.proto
+++ b/app/router/command/command.proto
@@ -115,6 +115,31 @@ message ListRuleResponse{
   repeated ListRuleItem rules = 1;
 }
 
+message RuleSetVersion {
+  string instance_id = 1;
+  uint64 generation = 2;
+}
+
+message GetRuleSetRequest {
+  // Controllers that already own desired state can request only the version
+  // and avoid transferring a potentially large routing config.
+  bool include_config = 1;
+}
+
+message GetRuleSetResponse {
+  RuleSetVersion version = 1;
+  xray.common.serial.TypedMessage config = 2;
+}
+
+message ReplaceRuleSetRequest {
+  RuleSetVersion expected_version = 1;
+  xray.common.serial.TypedMessage config = 2;
+}
+
+message ReplaceRuleSetResponse {
+  RuleSetVersion version = 1;
+}
+
 service RoutingService {
   rpc SubscribeRoutingStats(SubscribeRoutingStatsRequest)
       returns (stream RoutingContext) {}
@@ -127,6 +152,8 @@ service RoutingService {
   rpc RemoveRule(RemoveRuleRequest) returns (RemoveRuleResponse) {}
 
   rpc ListRule(ListRuleRequest) returns (ListRuleResponse) {}
+  rpc GetRuleSet(GetRuleSetRequest) returns (GetRuleSetResponse) {}
+  rpc ReplaceRuleSet(ReplaceRuleSetRequest) returns (ReplaceRuleSetResponse) {}
 }
 
 message Config {}

--- a/app/router/command/command_grpc.pb.go
+++ b/app/router/command/command_grpc.pb.go
@@ -26,6 +26,8 @@ const (
 	RoutingService_AddRule_FullMethodName                = "/xray.app.router.command.RoutingService/AddRule"
 	RoutingService_RemoveRule_FullMethodName             = "/xray.app.router.command.RoutingService/RemoveRule"
 	RoutingService_ListRule_FullMethodName               = "/xray.app.router.command.RoutingService/ListRule"
+	RoutingService_GetRuleSet_FullMethodName             = "/xray.app.router.command.RoutingService/GetRuleSet"
+	RoutingService_ReplaceRuleSet_FullMethodName         = "/xray.app.router.command.RoutingService/ReplaceRuleSet"
 )
 
 // RoutingServiceClient is the client API for RoutingService service.
@@ -39,6 +41,8 @@ type RoutingServiceClient interface {
 	AddRule(ctx context.Context, in *AddRuleRequest, opts ...grpc.CallOption) (*AddRuleResponse, error)
 	RemoveRule(ctx context.Context, in *RemoveRuleRequest, opts ...grpc.CallOption) (*RemoveRuleResponse, error)
 	ListRule(ctx context.Context, in *ListRuleRequest, opts ...grpc.CallOption) (*ListRuleResponse, error)
+	GetRuleSet(ctx context.Context, in *GetRuleSetRequest, opts ...grpc.CallOption) (*GetRuleSetResponse, error)
+	ReplaceRuleSet(ctx context.Context, in *ReplaceRuleSetRequest, opts ...grpc.CallOption) (*ReplaceRuleSetResponse, error)
 }
 
 type routingServiceClient struct {
@@ -128,6 +132,26 @@ func (c *routingServiceClient) ListRule(ctx context.Context, in *ListRuleRequest
 	return out, nil
 }
 
+func (c *routingServiceClient) GetRuleSet(ctx context.Context, in *GetRuleSetRequest, opts ...grpc.CallOption) (*GetRuleSetResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetRuleSetResponse)
+	err := c.cc.Invoke(ctx, RoutingService_GetRuleSet_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *routingServiceClient) ReplaceRuleSet(ctx context.Context, in *ReplaceRuleSetRequest, opts ...grpc.CallOption) (*ReplaceRuleSetResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReplaceRuleSetResponse)
+	err := c.cc.Invoke(ctx, RoutingService_ReplaceRuleSet_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // RoutingServiceServer is the server API for RoutingService service.
 // All implementations must embed UnimplementedRoutingServiceServer
 // for forward compatibility.
@@ -139,6 +163,8 @@ type RoutingServiceServer interface {
 	AddRule(context.Context, *AddRuleRequest) (*AddRuleResponse, error)
 	RemoveRule(context.Context, *RemoveRuleRequest) (*RemoveRuleResponse, error)
 	ListRule(context.Context, *ListRuleRequest) (*ListRuleResponse, error)
+	GetRuleSet(context.Context, *GetRuleSetRequest) (*GetRuleSetResponse, error)
+	ReplaceRuleSet(context.Context, *ReplaceRuleSetRequest) (*ReplaceRuleSetResponse, error)
 	mustEmbedUnimplementedRoutingServiceServer()
 }
 
@@ -169,6 +195,12 @@ func (UnimplementedRoutingServiceServer) RemoveRule(context.Context, *RemoveRule
 }
 func (UnimplementedRoutingServiceServer) ListRule(context.Context, *ListRuleRequest) (*ListRuleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListRule not implemented")
+}
+func (UnimplementedRoutingServiceServer) GetRuleSet(context.Context, *GetRuleSetRequest) (*GetRuleSetResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetRuleSet not implemented")
+}
+func (UnimplementedRoutingServiceServer) ReplaceRuleSet(context.Context, *ReplaceRuleSetRequest) (*ReplaceRuleSetResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ReplaceRuleSet not implemented")
 }
 func (UnimplementedRoutingServiceServer) mustEmbedUnimplementedRoutingServiceServer() {}
 func (UnimplementedRoutingServiceServer) testEmbeddedByValue()                        {}
@@ -310,6 +342,42 @@ func _RoutingService_ListRule_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RoutingService_GetRuleSet_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetRuleSetRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RoutingServiceServer).GetRuleSet(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RoutingService_GetRuleSet_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RoutingServiceServer).GetRuleSet(ctx, req.(*GetRuleSetRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RoutingService_ReplaceRuleSet_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReplaceRuleSetRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RoutingServiceServer).ReplaceRuleSet(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RoutingService_ReplaceRuleSet_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RoutingServiceServer).ReplaceRuleSet(ctx, req.(*ReplaceRuleSetRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // RoutingService_ServiceDesc is the grpc.ServiceDesc for RoutingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -340,6 +408,14 @@ var RoutingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListRule",
 			Handler:    _RoutingService_ListRule_Handler,
+		},
+		{
+			MethodName: "GetRuleSet",
+			Handler:    _RoutingService_GetRuleSet_Handler,
+		},
+		{
+			MethodName: "ReplaceRuleSet",
+			Handler:    _RoutingService_ReplaceRuleSet_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/app/router/command/command_test.go
+++ b/app/router/command/command_test.go
@@ -14,10 +14,13 @@ import (
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/geodata"
 	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/testing/mocks"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -431,4 +434,163 @@ func TestServiceTestRoute(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
+
+func TestServiceRuleSetAPI(t *testing.T) {
+	r := new(router.Router)
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	if err := r.Init(context.Background(), commandRuleSetConfig("initial"), mocks.NewDNSClient(mockCtl), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	server := NewRoutingServer(r, nil)
+	current, err := server.GetRuleSet(context.Background(), &GetRuleSetRequest{IncludeConfig: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Version == nil || current.Version.InstanceId == "" {
+		t.Fatalf("invalid initial version: %+v", current.Version)
+	}
+	if current.Version.Generation != 1 {
+		t.Fatalf("initial generation = %d, want 1", current.Version.Generation)
+	}
+	if current.Config == nil {
+		t.Fatal("initial config is nil")
+	}
+	versionOnly, err := server.GetRuleSet(context.Background(), &GetRuleSetRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if versionOnly.Config != nil {
+		t.Fatal("version-only response unexpectedly included config")
+	}
+
+	replaced, err := server.ReplaceRuleSet(context.Background(), &ReplaceRuleSetRequest{
+		ExpectedVersion: current.Version,
+		Config:          serial.ToTypedMessage(commandRuleSetConfig("replacement")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replaced.Version.Generation != current.Version.Generation+1 {
+		t.Fatalf("replacement generation = %d, want %d", replaced.Version.Generation, current.Version.Generation+1)
+	}
+
+	tests := []struct {
+		name string
+		req  *ReplaceRuleSetRequest
+		code codes.Code
+	}{
+		{
+			name: "missing expected version",
+			req: &ReplaceRuleSetRequest{
+				Config: serial.ToTypedMessage(commandRuleSetConfig("unused")),
+			},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "missing instance ID",
+			req: &ReplaceRuleSetRequest{
+				ExpectedVersion: &RuleSetVersion{Generation: replaced.Version.Generation},
+				Config:          serial.ToTypedMessage(commandRuleSetConfig("unused")),
+			},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "missing generation",
+			req: &ReplaceRuleSetRequest{
+				ExpectedVersion: &RuleSetVersion{InstanceId: replaced.Version.InstanceId},
+				Config:          serial.ToTypedMessage(commandRuleSetConfig("unused")),
+			},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "missing config",
+			req: &ReplaceRuleSetRequest{
+				ExpectedVersion: replaced.Version,
+			},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "stale generation",
+			req: &ReplaceRuleSetRequest{
+				ExpectedVersion: current.Version,
+				Config:          serial.ToTypedMessage(commandRuleSetConfig("unused")),
+			},
+			code: codes.Aborted,
+		},
+		{
+			name: "wrong instance",
+			req: &ReplaceRuleSetRequest{
+				ExpectedVersion: &RuleSetVersion{
+					InstanceId: "other-instance",
+					Generation: replaced.Version.Generation,
+				},
+				Config: serial.ToTypedMessage(commandRuleSetConfig("unused")),
+			},
+			code: codes.FailedPrecondition,
+		},
+		{
+			name: "wrong config type",
+			req: &ReplaceRuleSetRequest{
+				ExpectedVersion: replaced.Version,
+				Config:          serial.ToTypedMessage(&net.PortList{}),
+			},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "invalid config",
+			req: &ReplaceRuleSetRequest{
+				ExpectedVersion: replaced.Version,
+				Config: serial.ToTypedMessage(&router.Config{Rule: []*router.RoutingRule{{
+					TargetTag: &router.RoutingRule_Tag{Tag: "invalid"},
+				}}}),
+			},
+			code: codes.InvalidArgument,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := server.ReplaceRuleSet(context.Background(), test.req)
+			if got := status.Code(err); got != test.code {
+				t.Fatalf("status code = %s, want %s (error: %v)", got, test.code, err)
+			}
+		})
+	}
+
+	afterFailures, err := server.GetRuleSet(context.Background(), &GetRuleSetRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(afterFailures.Version, replaced.Version, cmpopts.IgnoreUnexported(RuleSetVersion{})); diff != "" {
+		t.Fatalf("version changed after failed replacements (-got +want):\n%s", diff)
+	}
+}
+
+func TestServiceRuleSetAPIUnsupported(t *testing.T) {
+	server := NewRoutingServer(routing.DefaultRouter{}, nil)
+	if _, err := server.GetRuleSet(context.Background(), &GetRuleSetRequest{}); status.Code(err) != codes.Unimplemented {
+		t.Fatalf("GetRuleSet status = %s, want Unimplemented", status.Code(err))
+	}
+	if _, err := server.ReplaceRuleSet(context.Background(), &ReplaceRuleSetRequest{}); status.Code(err) != codes.Unimplemented {
+		t.Fatalf("ReplaceRuleSet status = %s, want Unimplemented", status.Code(err))
+	}
+}
+
+func TestServiceRuleSetAPIUnavailable(t *testing.T) {
+	r := new(router.Router)
+	server := NewRoutingServer(r, nil)
+	if _, err := server.GetRuleSet(context.Background(), &GetRuleSetRequest{}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("GetRuleSet status = %s, want FailedPrecondition", status.Code(err))
+	}
+}
+
+func commandRuleSetConfig(outboundTag string) *router.Config {
+	return &router.Config{Rule: []*router.RoutingRule{{
+		TargetTag: &router.RoutingRule_Tag{Tag: outboundTag},
+		RuleTag:   outboundTag + "-rule",
+		Networks:  []net.Network{net.Network_TCP},
+	}}}
 }

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -2,29 +2,62 @@ package router
 
 import (
 	"context"
+	stderrors "errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
+	xnet "github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/serial"
+	"github.com/xtls/xray-core/common/uuid"
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/dns"
+	"github.com/xtls/xray-core/features/extension"
 	"github.com/xtls/xray-core/features/outbound"
 	"github.com/xtls/xray-core/features/routing"
 	routing_dns "github.com/xtls/xray-core/features/routing/dns"
+	"google.golang.org/protobuf/proto"
 )
 
-// Router is an implementation of routing.Router.
-type Router struct {
+var (
+	// ErrRuleSetInvalidVersion indicates that a required version field is missing.
+	ErrRuleSetInvalidVersion = stderrors.New("invalid routing rule set version")
+	// ErrRuleSetInstanceMismatch indicates that the caller is addressing a stale router instance.
+	ErrRuleSetInstanceMismatch = stderrors.New("routing rule set instance mismatch")
+	// ErrRuleSetGenerationConflict indicates that the rule set changed since the caller read it.
+	ErrRuleSetGenerationConflict = stderrors.New("routing rule set generation conflict")
+	// ErrRuleSetUnavailable indicates that the router has no mutable rule set.
+	ErrRuleSetUnavailable = stderrors.New("routing rule set unavailable")
+)
+
+// RuleSetVersion identifies one immutable router rule set.
+type RuleSetVersion struct {
+	InstanceID string
+	Generation uint64
+}
+
+type ruleSetState struct {
+	version        RuleSetVersion
 	domainStrategy Config_DomainStrategy
 	rules          []*Rule
 	balancers      map[string]*Balancer
-	dns            dns.Client
+	config         *Config
+}
+
+// Router is an implementation of routing.Router.
+type Router struct {
+	dns dns.Client
 
 	ctx        context.Context
 	ohm        outbound.Manager
 	dispatcher routing.Dispatcher
-	mu         sync.Mutex
+
+	mu    sync.RWMutex
+	state *ruleSetState
 }
 
 // Route is an implementation of routing.Route.
@@ -37,64 +70,41 @@ type Route struct {
 
 // Init initializes the Router.
 func (r *Router) Init(ctx context.Context, config *Config, d dns.Client, ohm outbound.Manager, dispatcher routing.Dispatcher) error {
-	r.domainStrategy = config.DomainStrategy
-	r.dns = d
+	state, err := buildRuleSet(ctx, config, ohm, dispatcher)
+	if err != nil {
+		return err
+	}
+	instanceID := uuid.New()
+	state.version = RuleSetVersion{
+		InstanceID: instanceID.String(),
+		Generation: 1,
+	}
+
+	r.mu.Lock()
+	oldState := r.state
 	r.ctx = ctx
 	r.ohm = ohm
 	r.dispatcher = dispatcher
+	r.dns = d
+	r.state = state
+	r.mu.Unlock()
 
-	r.balancers = make(map[string]*Balancer, len(config.BalancingRule))
-	for _, rule := range config.BalancingRule {
-		balancer, err := rule.Build(ohm, dispatcher)
-		if err != nil {
-			return err
-		}
-		balancer.InjectContext(ctx)
-		r.balancers[rule.Tag] = balancer
-	}
-
-	r.rules = make([]*Rule, 0, len(config.Rule))
-	for _, rule := range config.Rule {
-		cond, err := rule.BuildCondition()
-		if err != nil {
-			r.closeWebhooks()
-			return err
-		}
-		rr := &Rule{
-			Condition: cond,
-			Tag:       rule.GetTag(),
-			RuleTag:   rule.GetRuleTag(),
-		}
-		if wh := rule.GetWebhook(); wh != nil {
-			notifier, err := NewWebhookNotifier(wh)
-			if err != nil {
-				r.closeWebhooks()
-				return err
-			}
-			rr.Webhook = notifier
-		}
-		btag := rule.GetBalancingTag()
-		if len(btag) > 0 {
-			brule, found := r.balancers[btag]
-			if !found {
-				if rr.Webhook != nil {
-					rr.Webhook.Close()
-				}
-				r.closeWebhooks()
-				return errors.New("balancer ", btag, " not found")
-			}
-			rr.Balancer = brule
-		}
-		r.rules = append(r.rules, rr)
-	}
-
+	closeRuleSet(oldState)
 	return nil
 }
 
 // PickRoute implements routing.Router.
 func (r *Router) PickRoute(ctx routing.Context) (routing.Route, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	state := r.state
+	if state == nil {
+		return nil, ErrRuleSetUnavailable
+	}
+
 	originalCtx := ctx
-	rule, ctx, err := r.pickRouteInternal(ctx)
+	rule, ctx, err := r.pickRouteInternal(state, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -110,99 +120,51 @@ func (r *Router) PickRoute(ctx routing.Context) (routing.Route, error) {
 
 // AddRule implements routing.Router.
 func (r *Router) AddRule(config *serial.TypedMessage, shouldAppend bool) error {
-	inst, err := config.GetInstance()
+	ruleConfig, err := parseRuleSetConfig(config)
 	if err != nil {
 		return err
 	}
-	if c, ok := inst.(*Config); ok {
-		return r.ReloadRules(c, shouldAppend)
-	}
-	return errors.New("AddRule: config type error")
+	return r.ReloadRules(ruleConfig, shouldAppend)
 }
 
+// ReloadRules applies the legacy AddRule behavior using a copy-on-write snapshot.
+// DomainStrategy remains a startup/versioned-rule-set setting for compatibility
+// with the previous implementation.
 func (r *Router) ReloadRules(config *Config, shouldAppend bool) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if !shouldAppend {
-		for _, rule := range r.rules {
-			if rule.Webhook != nil {
-				rule.Webhook.Close()
-			}
-		}
-		r.balancers = make(map[string]*Balancer, len(config.BalancingRule))
-		r.rules = make([]*Rule, 0, len(config.Rule))
+	if config == nil {
+		return errors.New("routing rule set config is nil")
 	}
-	for _, rule := range config.BalancingRule {
-		_, found := r.balancers[rule.Tag]
-		if found {
-			return errors.New("duplicate balancer tag")
-		}
-		balancer, err := rule.Build(r.ohm, r.dispatcher)
-		if err != nil {
-			return err
-		}
-		balancer.InjectContext(r.ctx)
-		r.balancers[rule.Tag] = balancer
-	}
+	addition := cloneRuleSetConfig(config)
 
-	startIdx := len(r.rules)
-	closeNewWebhooks := func() {
-		for i := startIdx; i < len(r.rules); i++ {
-			if r.rules[i].Webhook != nil {
-				r.rules[i].Webhook.Close()
-			}
+	return r.mutateRuleSet(func(current *Config) (*Config, bool, error) {
+		if !shouldAppend {
+			addition.DomainStrategy = current.DomainStrategy
+			return cloneRuleSetConfig(addition), true, nil
 		}
-		r.rules = r.rules[:startIdx]
-	}
-
-	for _, rule := range config.Rule {
-		if r.RuleExists(rule.GetRuleTag()) {
-			closeNewWebhooks()
-			return errors.New("duplicate ruleTag ", rule.GetRuleTag())
+		if len(addition.Rule) == 0 && len(addition.BalancingRule) == 0 {
+			return current, false, nil
 		}
-		cond, err := rule.BuildCondition()
-		if err != nil {
-			closeNewWebhooks()
-			return err
-		}
-		rr := &Rule{
-			Condition: cond,
-			Tag:       rule.GetTag(),
-			RuleTag:   rule.GetRuleTag(),
-		}
-		if wh := rule.GetWebhook(); wh != nil {
-			notifier, err := NewWebhookNotifier(wh)
-			if err != nil {
-				closeNewWebhooks()
-				return err
-			}
-			rr.Webhook = notifier
-		}
-		btag := rule.GetBalancingTag()
-		if len(btag) > 0 {
-			brule, found := r.balancers[btag]
-			if !found {
-				if rr.Webhook != nil {
-					rr.Webhook.Close()
-				}
-				closeNewWebhooks()
-				return errors.New("balancer ", btag, " not found")
-			}
-			rr.Balancer = brule
-		}
-		r.rules = append(r.rules, rr)
-	}
-
-	return nil
+		appended := cloneRuleSetConfig(addition)
+		current.Rule = append(current.Rule, appended.Rule...)
+		current.BalancingRule = append(current.BalancingRule, appended.BalancingRule...)
+		return current, true, nil
+	})
 }
 
+// RuleExists reports whether the current rule set contains tag.
 func (r *Router) RuleExists(tag string) bool {
-	if tag != "" {
-		for _, rule := range r.rules {
-			if rule.RuleTag == tag {
-				return true
-			}
+	if tag == "" {
+		return false
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.state == nil {
+		return false
+	}
+	for _, rule := range r.state.rules {
+		if rule.RuleTag == tag {
+			return true
 		}
 	}
 	return false
@@ -210,30 +172,38 @@ func (r *Router) RuleExists(tag string) bool {
 
 // RemoveRule implements routing.Router.
 func (r *Router) RemoveRule(tag string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	newRules := []*Rule{}
-	if tag != "" {
-		for _, rule := range r.rules {
-			if rule.RuleTag != tag {
-				newRules = append(newRules, rule)
-			} else if rule.Webhook != nil {
-				rule.Webhook.Close()
-			}
-		}
-		r.rules = newRules
-		return nil
+	if tag == "" {
+		return errors.New("empty tag name")
 	}
-	return errors.New("empty tag name!")
+
+	return r.mutateRuleSet(func(current *Config) (*Config, bool, error) {
+		rules := make([]*RoutingRule, 0, len(current.Rule))
+		removed := false
+		for _, rule := range current.Rule {
+			if rule.GetRuleTag() == tag {
+				removed = true
+				continue
+			}
+			rules = append(rules, rule)
+		}
+		if !removed {
+			return current, false, nil
+		}
+		current.Rule = rules
+		return current, true, nil
+	})
 }
 
-// ListRule implements routing.Router
+// ListRule implements routing.Router.
 func (r *Router) ListRule() []routing.Route {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	ruleList := make([]routing.Route, 0)
-	for _, rule := range r.rules {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.state == nil {
+		return nil
+	}
+
+	ruleList := make([]routing.Route, 0, len(r.state.rules))
+	for _, rule := range r.state.rules {
 		ruleList = append(ruleList, &Route{
 			outboundTag: rule.Tag,
 			ruleTag:     rule.RuleTag,
@@ -242,30 +212,438 @@ func (r *Router) ListRule() []routing.Route {
 	return ruleList
 }
 
-func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, routing.Context, error) {
+// GetRuleSet returns a defensive copy of the current rule set and its version.
+func (r *Router) GetRuleSet() (RuleSetVersion, *serial.TypedMessage, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.state == nil {
+		return RuleSetVersion{}, nil, ErrRuleSetUnavailable
+	}
+	return r.state.version, serial.ToTypedMessage(r.state.config), nil
+}
+
+// GetRuleSetVersion returns the current version without serializing the config.
+func (r *Router) GetRuleSetVersion() (RuleSetVersion, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.state == nil {
+		return RuleSetVersion{}, ErrRuleSetUnavailable
+	}
+	return r.state.version, nil
+}
+
+// ReplaceRuleSet atomically publishes config when expected still identifies the
+// current rule set. The current state is left unchanged on validation errors or
+// version conflicts.
+func (r *Router) ReplaceRuleSet(expected RuleSetVersion, config *serial.TypedMessage) (RuleSetVersion, error) {
+	ruleConfig, err := parseRuleSetConfig(config)
+	if err != nil {
+		return RuleSetVersion{}, err
+	}
+
+	r.mu.RLock()
+	if err := validateRuleSetVersion(r.state, expected); err != nil {
+		r.mu.RUnlock()
+		return RuleSetVersion{}, err
+	}
+	ctx, ohm, dispatcher := r.ctx, r.ohm, r.dispatcher
+	r.mu.RUnlock()
+
+	if err := validateRuleSetRuntimeDependencies(ctx, ruleConfig); err != nil {
+		return RuleSetVersion{}, err
+	}
+	candidate, err := buildRuleSet(ctx, ruleConfig, ohm, dispatcher)
+	if err != nil {
+		return RuleSetVersion{}, err
+	}
+
+	r.mu.Lock()
+	if err := validateRuleSetVersion(r.state, expected); err != nil {
+		r.mu.Unlock()
+		closeRuleSet(candidate)
+		return RuleSetVersion{}, err
+	}
+	if r.state.version.Generation == math.MaxUint64 {
+		r.mu.Unlock()
+		closeRuleSet(candidate)
+		return RuleSetVersion{}, ErrRuleSetUnavailable
+	}
+	candidate.version = RuleSetVersion{
+		InstanceID: r.state.version.InstanceID,
+		Generation: r.state.version.Generation + 1,
+	}
+	oldState := r.state
+	preserveBalancerRuntimeState(oldState, candidate)
+	r.state = candidate
+	version := candidate.version
+	r.mu.Unlock()
+
+	closeRuleSet(oldState)
+	return version, nil
+}
+
+func (r *Router) mutateRuleSet(mutate func(*Config) (*Config, bool, error)) error {
+	for {
+		r.mu.RLock()
+		if r.state == nil {
+			r.mu.RUnlock()
+			return ErrRuleSetUnavailable
+		}
+		baseVersion := r.state.version
+		current := cloneRuleSetConfig(r.state.config)
+		ctx, ohm, dispatcher := r.ctx, r.ohm, r.dispatcher
+		r.mu.RUnlock()
+
+		next, changed, err := mutate(current)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			return nil
+		}
+
+		if err := validateRuleSetRuntimeDependencies(ctx, next); err != nil {
+			return err
+		}
+		candidate, err := buildRuleSet(ctx, next, ohm, dispatcher)
+		if err != nil {
+			return err
+		}
+
+		r.mu.Lock()
+		if r.state == nil {
+			r.mu.Unlock()
+			closeRuleSet(candidate)
+			return ErrRuleSetUnavailable
+		}
+		if r.state.version != baseVersion {
+			r.mu.Unlock()
+			closeRuleSet(candidate)
+			continue
+		}
+		if r.state.version.Generation == math.MaxUint64 {
+			r.mu.Unlock()
+			closeRuleSet(candidate)
+			return ErrRuleSetUnavailable
+		}
+		candidate.version = RuleSetVersion{
+			InstanceID: r.state.version.InstanceID,
+			Generation: r.state.version.Generation + 1,
+		}
+		oldState := r.state
+		preserveBalancerRuntimeState(oldState, candidate)
+		r.state = candidate
+		r.mu.Unlock()
+
+		closeRuleSet(oldState)
+		return nil
+	}
+}
+
+func validateRuleSetVersion(state *ruleSetState, expected RuleSetVersion) error {
+	if expected.InstanceID == "" || expected.Generation == 0 {
+		return ErrRuleSetInvalidVersion
+	}
+	if state == nil {
+		return ErrRuleSetUnavailable
+	}
+	if expected.InstanceID != state.version.InstanceID {
+		return fmt.Errorf(
+			"%w: expected instance %q, current instance %q",
+			ErrRuleSetInstanceMismatch,
+			expected.InstanceID,
+			state.version.InstanceID,
+		)
+	}
+	if expected.Generation != state.version.Generation {
+		return fmt.Errorf(
+			"%w: expected generation %d, current generation %d",
+			ErrRuleSetGenerationConflict,
+			expected.Generation,
+			state.version.Generation,
+		)
+	}
+	return nil
+}
+
+func parseRuleSetConfig(message *serial.TypedMessage) (*Config, error) {
+	if message == nil {
+		return nil, errors.New("routing rule set config is nil")
+	}
+	instance, err := message.GetInstance()
+	if err != nil {
+		return nil, errors.New("failed to parse routing rule set config").Base(err)
+	}
+	config, ok := instance.(*Config)
+	if !ok {
+		return nil, errors.New("routing rule set config type is invalid")
+	}
+	return config, nil
+}
+
+func cloneRuleSetConfig(config *Config) *Config {
+	if config == nil {
+		return nil
+	}
+	return proto.Clone(config).(*Config)
+}
+
+func buildRuleSet(
+	ctx context.Context,
+	config *Config,
+	ohm outbound.Manager,
+	dispatcher routing.Dispatcher,
+) (*ruleSetState, error) {
+	if config == nil {
+		return nil, errors.New("routing rule set config is nil")
+	}
+	config = cloneRuleSetConfig(config)
+	switch config.DomainStrategy {
+	case Config_AsIs, Config_IpIfNonMatch, Config_IpOnDemand:
+	default:
+		return nil, errors.New("invalid domain strategy: ", config.DomainStrategy)
+	}
+
+	state := &ruleSetState{
+		domainStrategy: config.DomainStrategy,
+		balancers:      make(map[string]*Balancer, len(config.BalancingRule)),
+		rules:          make([]*Rule, 0, len(config.Rule)),
+		config:         config,
+	}
+
+	for index, balancingRule := range config.BalancingRule {
+		if balancingRule == nil {
+			return nil, errors.New("nil balancing rule at index ", index)
+		}
+		if _, found := state.balancers[balancingRule.Tag]; found {
+			return nil, errors.New("duplicate balancer tag: ", balancingRule.Tag)
+		}
+		if strings.EqualFold(balancingRule.Strategy, "leastload") && balancingRule.StrategySettings == nil {
+			return nil, errors.New("leastload balancer ", balancingRule.Tag, " has no strategy settings")
+		}
+		balancer, err := buildBalancer(ctx, balancingRule, ohm, dispatcher)
+		if err != nil {
+			return nil, errors.New("failed to build balancer ", balancingRule.Tag).Base(err)
+		}
+		if strategy, ok := balancer.strategy.(*LeastLoadStrategy); ok {
+			for costIndex, cost := range strategy.settings.Costs {
+				if cost == nil {
+					return nil, errors.New(
+						"leastload balancer ",
+						balancingRule.Tag,
+						" has nil cost at index ",
+						costIndex,
+					)
+				}
+			}
+		}
+		state.balancers[balancingRule.Tag] = balancer
+	}
+
+	ruleTags := make(map[string]struct{}, len(config.Rule))
+	for index, routingRule := range config.Rule {
+		if routingRule == nil {
+			closeRuleSet(state)
+			return nil, errors.New("nil routing rule at index ", index)
+		}
+		if routingRule.GetTag() == "" && routingRule.GetBalancingTag() == "" {
+			closeRuleSet(state)
+			return nil, errors.New("routing rule at index ", index, " has no target tag")
+		}
+		if tag := routingRule.GetRuleTag(); tag != "" {
+			if _, found := ruleTags[tag]; found {
+				closeRuleSet(state)
+				return nil, errors.New("duplicate ruleTag ", tag)
+			}
+			ruleTags[tag] = struct{}{}
+		}
+		for key, value := range routingRule.Attributes {
+			if _, err := regexp.Compile(value); err != nil {
+				closeRuleSet(state)
+				return nil, errors.New("invalid attribute regexp for ", key).Base(err)
+			}
+		}
+		for _, network := range routingRule.Networks {
+			switch network {
+			case xnet.Network_Unknown, xnet.Network_TCP, xnet.Network_UDP, xnet.Network_UNIX:
+			default:
+				closeRuleSet(state)
+				return nil, errors.New("invalid network ", network, " in routing rule at index ", index)
+			}
+		}
+
+		condition, err := buildRoutingCondition(routingRule)
+		if err != nil {
+			closeRuleSet(state)
+			return nil, errors.New("failed to build routing rule at index ", index).Base(err)
+		}
+		rule := &Rule{
+			Condition: condition,
+			Tag:       routingRule.GetTag(),
+			RuleTag:   routingRule.GetRuleTag(),
+		}
+		if balancerTag := routingRule.GetBalancingTag(); balancerTag != "" {
+			balancer, found := state.balancers[balancerTag]
+			if !found {
+				closeRuleSet(state)
+				return nil, errors.New("balancer ", balancerTag, " not found")
+			}
+			rule.Balancer = balancer
+		}
+		if webhookConfig := routingRule.GetWebhook(); webhookConfig != nil {
+			notifier, err := NewWebhookNotifier(webhookConfig)
+			if err != nil {
+				closeRuleSet(state)
+				return nil, errors.New("failed to build webhook for routing rule at index ", index).Base(err)
+			}
+			rule.Webhook = notifier
+		}
+		state.rules = append(state.rules, rule)
+	}
+
+	return state, nil
+}
+
+func buildBalancer(
+	ctx context.Context,
+	config *BalancingRule,
+	ohm outbound.Manager,
+	dispatcher routing.Dispatcher,
+) (balancer *Balancer, err error) {
+	defer func() {
+		if value := recover(); value != nil {
+			err = fmt.Errorf("balancer initialization panicked: %v", value)
+			balancer = nil
+		}
+	}()
+
+	balancer, err = config.Build(ohm, dispatcher)
+	if err == nil {
+		balancer.InjectContext(ctx)
+	}
+	return balancer, err
+}
+
+func buildRoutingCondition(config *RoutingRule) (condition Condition, err error) {
+	defer func() {
+		if value := recover(); value != nil {
+			err = fmt.Errorf("routing condition initialization panicked: %v", value)
+			condition = nil
+		}
+	}()
+	return config.BuildCondition()
+}
+
+func validateRuleSetRuntimeDependencies(ctx context.Context, config *Config) error {
+	if !ruleSetRequiresObservatory(config) {
+		return nil
+	}
+	instance := core.FromContext(ctx)
+	if instance == nil {
+		return errors.New("routing rule set requires an Xray instance with Observatory")
+	}
+	if instance.GetFeature(extension.ObservatoryType()) == nil {
+		return errors.New("routing rule set requires the Observatory feature")
+	}
+	return nil
+}
+
+func ruleSetRequiresObservatory(config *Config) bool {
+	if config == nil {
+		return false
+	}
+	for _, rule := range config.BalancingRule {
+		if rule == nil {
+			continue
+		}
+		switch strings.ToLower(rule.Strategy) {
+		case "leastping", "leastload":
+			return true
+		case "", "random", "roundrobin":
+			if rule.FallbackTag != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func closeRuleSet(state *ruleSetState) {
+	if state == nil {
+		return
+	}
+	for _, rule := range state.rules {
+		if rule.Webhook != nil {
+			_ = rule.Webhook.Close()
+		}
+	}
+}
+
+// preserveBalancerRuntimeState keeps a logically unchanged balancer alive
+// across a snapshot replacement. This preserves strategy state such as the
+// round-robin cursor as well as the runtime override. When the balancer config
+// changed, only its override is carried forward. The caller must hold Router.mu
+// for writing so route selection and override updates cannot race the transfer.
+func preserveBalancerRuntimeState(current, candidate *ruleSetState) {
+	if current == nil || candidate == nil {
+		return
+	}
+	for tag, candidateBalancer := range candidate.balancers {
+		currentBalancer, found := current.balancers[tag]
+		if !found {
+			continue
+		}
+		currentConfig := balancingRuleByTag(current.config, tag)
+		candidateConfig := balancingRuleByTag(candidate.config, tag)
+		if currentConfig != nil && candidateConfig != nil && proto.Equal(currentConfig, candidateConfig) {
+			candidate.balancers[tag] = currentBalancer
+			for _, rule := range candidate.rules {
+				if rule.Balancer == candidateBalancer {
+					rule.Balancer = currentBalancer
+				}
+			}
+			continue
+		}
+		candidateBalancer.override.Put(currentBalancer.override.Get())
+	}
+}
+
+func balancingRuleByTag(config *Config, tag string) *BalancingRule {
+	if config == nil {
+		return nil
+	}
+	for _, rule := range config.BalancingRule {
+		if rule != nil && rule.Tag == tag {
+			return rule
+		}
+	}
+	return nil
+}
+
+func (r *Router) pickRouteInternal(state *ruleSetState, ctx routing.Context) (*Rule, routing.Context, error) {
 	// SkipDNSResolve is set from DNS module.
 	// the DOH remote server maybe a domain name,
 	// this prevents cycle resolving dead loop
 	skipDNSResolve := ctx.GetSkipDNSResolve()
 
-	if r.domainStrategy == Config_IpOnDemand && !skipDNSResolve {
+	if state.domainStrategy == Config_IpOnDemand && !skipDNSResolve {
 		ctx = routing_dns.ContextWithDNSClient(ctx, r.dns)
 	}
 
-	for _, rule := range r.rules {
+	for _, rule := range state.rules {
 		if rule.Apply(ctx) {
 			return rule, ctx, nil
 		}
 	}
 
-	if r.domainStrategy != Config_IpIfNonMatch || len(ctx.GetTargetDomain()) == 0 || skipDNSResolve {
+	if state.domainStrategy != Config_IpIfNonMatch || len(ctx.GetTargetDomain()) == 0 || skipDNSResolve {
 		return nil, ctx, common.ErrNoClue
 	}
 
 	ctx = routing_dns.ContextWithDNSClient(ctx, r.dns)
 
 	// Try applying rules again if we have IPs.
-	for _, rule := range r.rules {
+	for _, rule := range state.rules {
 		if rule.Apply(ctx) {
 			return rule, ctx, nil
 		}
@@ -279,20 +657,14 @@ func (r *Router) Start() error {
 	return nil
 }
 
-// closeWebhooks closes all webhook notifiers in the current rule set.
-func (r *Router) closeWebhooks() {
-	for _, rule := range r.rules {
-		if rule.Webhook != nil {
-			rule.Webhook.Close()
-		}
-	}
-}
-
 // Close implements common.Closable.
 func (r *Router) Close() error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.closeWebhooks()
+	oldState := r.state
+	r.state = nil
+	r.mu.Unlock()
+
+	closeRuleSet(oldState)
 	return nil
 }
 

--- a/app/router/ruleset_test.go
+++ b/app/router/ruleset_test.go
@@ -1,0 +1,613 @@
+package router_test
+
+import (
+	"context"
+	stderrors "errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/xtls/xray-core/app/router"
+	"github.com/xtls/xray-core/common/geodata"
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/serial"
+	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/core"
+	"github.com/xtls/xray-core/features/outbound"
+	routing_session "github.com/xtls/xray-core/features/routing/session"
+)
+
+type staticOutboundManager struct {
+	outbound.Manager
+}
+
+func (*staticOutboundManager) Select([]string) []string {
+	return []string{"selected"}
+}
+
+type orderedOutboundManager struct {
+	outbound.Manager
+}
+
+func (*orderedOutboundManager) Select([]string) []string {
+	return []string{"first", "second"}
+}
+
+func TestRouterReplaceRuleSetCAS(t *testing.T) {
+	r := new(Router)
+	if err := r.Init(context.Background(), ruleSetConfig("initial", "initial-rule"), nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	initialVersion, initialConfig, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if initialVersion.InstanceID == "" {
+		t.Fatal("initial instance ID is empty")
+	}
+	if initialVersion.Generation != 1 {
+		t.Fatalf("initial generation = %d, want 1", initialVersion.Generation)
+	}
+
+	initialConfig.Value[0] ^= 0xff
+	_, freshConfig, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := decodedRuleSet(t, freshConfig).Rule[0].GetTag(); got != "initial" {
+		t.Fatalf("stored config changed through returned value: got %q", got)
+	}
+
+	replacement := serial.ToTypedMessage(ruleSetConfig("replacement", "replacement-rule"))
+	replacedVersion, err := r.ReplaceRuleSet(initialVersion, replacement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacedVersion.InstanceID != initialVersion.InstanceID {
+		t.Fatalf("instance ID changed: got %q, want %q", replacedVersion.InstanceID, initialVersion.InstanceID)
+	}
+	if replacedVersion.Generation != initialVersion.Generation+1 {
+		t.Fatalf("generation = %d, want %d", replacedVersion.Generation, initialVersion.Generation+1)
+	}
+	if got := pickedOutbound(t, r); got != "replacement" {
+		t.Fatalf("outbound after replacement = %q, want replacement", got)
+	}
+
+	if _, err := r.ReplaceRuleSet(RuleSetVersion{
+		InstanceID: replacedVersion.InstanceID,
+	}, serial.ToTypedMessage(ruleSetConfig("missing-generation", "missing-generation-rule"))); !stderrors.Is(err, ErrRuleSetInvalidVersion) {
+		t.Fatalf("missing-generation replacement error = %v, want invalid version", err)
+	}
+	if _, err := r.ReplaceRuleSet(initialVersion, serial.ToTypedMessage(ruleSetConfig("stale", "stale-rule"))); !stderrors.Is(err, ErrRuleSetGenerationConflict) {
+		t.Fatalf("stale replacement error = %v, want generation conflict", err)
+	}
+	if _, err := r.ReplaceRuleSet(RuleSetVersion{
+		InstanceID: "other-instance",
+		Generation: replacedVersion.Generation,
+	}, serial.ToTypedMessage(ruleSetConfig("other", "other-rule"))); !stderrors.Is(err, ErrRuleSetInstanceMismatch) {
+		t.Fatalf("wrong-instance replacement error = %v, want instance mismatch", err)
+	}
+
+	invalidConfigs := []struct {
+		name   string
+		config *Config
+	}{
+		{
+			name: "conditionless rule",
+			config: &Config{Rule: []*RoutingRule{{
+				TargetTag: &RoutingRule_Tag{Tag: "invalid"},
+			}}},
+		},
+		{
+			name: "invalid attribute regexp",
+			config: &Config{Rule: []*RoutingRule{{
+				TargetTag: &RoutingRule_Tag{Tag: "invalid"},
+				Attributes: map[string]string{
+					"header": "[",
+				},
+			}}},
+		},
+		{
+			name: "missing balancer",
+			config: &Config{Rule: []*RoutingRule{{
+				TargetTag: &RoutingRule_BalancingTag{BalancingTag: "missing"},
+				Networks:  []net.Network{net.Network_TCP},
+			}}},
+		},
+		{
+			name: "invalid network",
+			config: &Config{Rule: []*RoutingRule{{
+				TargetTag: &RoutingRule_Tag{Tag: "invalid"},
+				Networks:  []net.Network{net.Network(100)},
+			}}},
+		},
+		{
+			name: "nil domain matcher",
+			config: &Config{Rule: []*RoutingRule{{
+				TargetTag: &RoutingRule_Tag{Tag: "invalid"},
+				Domain:    []*geodata.DomainRule{nil},
+			}}},
+		},
+		{
+			name: "balancer context initialization",
+			config: &Config{BalancingRule: []*BalancingRule{{
+				Tag:      "least-ping",
+				Strategy: "leastping",
+			}}},
+		},
+	}
+	for _, test := range invalidConfigs {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := r.ReplaceRuleSet(replacedVersion, serial.ToTypedMessage(test.config)); err == nil {
+				t.Fatal("invalid replacement succeeded")
+			}
+			currentVersion, _, err := r.GetRuleSet()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if currentVersion != replacedVersion {
+				t.Fatalf("version changed after failed replacement: got %+v, want %+v", currentVersion, replacedVersion)
+			}
+			if got := pickedOutbound(t, r); got != "replacement" {
+				t.Fatalf("outbound changed after failed replacement: got %q", got)
+			}
+		})
+	}
+}
+
+func TestRouterLegacyMutationsUseSnapshots(t *testing.T) {
+	r := new(Router)
+	if err := r.Init(context.Background(), ruleSetConfig("initial", "initial-rule"), nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	initialVersion, _, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	addition := &Config{Rule: []*RoutingRule{{
+		TargetTag: &RoutingRule_Tag{Tag: "udp"},
+		RuleTag:   "udp-rule",
+		Networks:  []net.Network{net.Network_UDP},
+	}}}
+	if err := r.AddRule(serial.ToTypedMessage(addition), true); err != nil {
+		t.Fatal(err)
+	}
+	addedVersion, _, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addedVersion.Generation != initialVersion.Generation+1 {
+		t.Fatalf("generation after add = %d, want %d", addedVersion.Generation, initialVersion.Generation+1)
+	}
+	if got := len(r.ListRule()); got != 2 {
+		t.Fatalf("rule count after add = %d, want 2", got)
+	}
+
+	duplicate := &Config{Rule: []*RoutingRule{{
+		TargetTag: &RoutingRule_Tag{Tag: "duplicate"},
+		RuleTag:   "udp-rule",
+		Networks:  []net.Network{net.Network_TCP},
+	}}}
+	if err := r.AddRule(serial.ToTypedMessage(duplicate), true); err == nil {
+		t.Fatal("duplicate rule add succeeded")
+	}
+	afterFailure, _, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterFailure != addedVersion {
+		t.Fatalf("version changed after failed add: got %+v, want %+v", afterFailure, addedVersion)
+	}
+
+	if err := r.RemoveRule("udp-rule"); err != nil {
+		t.Fatal(err)
+	}
+	removedVersion, _, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removedVersion.Generation != addedVersion.Generation+1 {
+		t.Fatalf("generation after remove = %d, want %d", removedVersion.Generation, addedVersion.Generation+1)
+	}
+	if got := len(r.ListRule()); got != 1 {
+		t.Fatalf("rule count after remove = %d, want 1", got)
+	}
+
+	if err := r.RemoveRule("not-present"); err != nil {
+		t.Fatal(err)
+	}
+	afterNoop, _, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterNoop != removedVersion {
+		t.Fatalf("version changed after no-op remove: got %+v, want %+v", afterNoop, removedVersion)
+	}
+}
+
+func TestRouterMutationsPreserveBalancerOverride(t *testing.T) {
+	manager := &staticOutboundManager{}
+	r := new(Router)
+	if err := r.Init(context.Background(), balancedRuleSetConfig(), nil, manager, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	const overrideTarget = "forced"
+	if err := r.SetOverrideTarget("balance", overrideTarget); err != nil {
+		t.Fatal(err)
+	}
+	assertOverride := func() {
+		t.Helper()
+		target, err := r.GetOverrideTarget("balance")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if target != overrideTarget {
+			t.Fatalf("override target = %q, want %q", target, overrideTarget)
+		}
+	}
+
+	version, _, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.ReplaceRuleSet(version, serial.ToTypedMessage(balancedRuleSetConfig())); err != nil {
+		t.Fatal(err)
+	}
+	assertOverride()
+
+	addition := &Config{Rule: []*RoutingRule{{
+		TargetTag: &RoutingRule_Tag{Tag: "udp"},
+		RuleTag:   "udp-rule",
+		Networks:  []net.Network{net.Network_UDP},
+	}}}
+	if err := r.AddRule(serial.ToTypedMessage(addition), true); err != nil {
+		t.Fatal(err)
+	}
+	assertOverride()
+
+	if err := r.RemoveRule("udp-rule"); err != nil {
+		t.Fatal(err)
+	}
+	assertOverride()
+}
+
+func TestRouterMutationsPreserveRoundRobinCursor(t *testing.T) {
+	r := new(Router)
+	config := &Config{
+		Rule: []*RoutingRule{{
+			TargetTag: &RoutingRule_BalancingTag{BalancingTag: "balance"},
+			RuleTag:   "balanced-rule",
+			Networks:  []net.Network{net.Network_TCP},
+		}},
+		BalancingRule: []*BalancingRule{{
+			Tag:              "balance",
+			OutboundSelector: []string{"candidate"},
+			Strategy:         "roundRobin",
+		}},
+	}
+	if err := r.Init(context.Background(), config, nil, &orderedOutboundManager{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	if got := pickedOutbound(t, r); got != "first" {
+		t.Fatalf("first round-robin selection = %q, want first", got)
+	}
+	if err := r.AddRule(serial.ToTypedMessage(&Config{Rule: []*RoutingRule{{
+		TargetTag: &RoutingRule_Tag{Tag: "udp"},
+		RuleTag:   "udp-rule",
+		Networks:  []net.Network{net.Network_UDP},
+	}}}), true); err != nil {
+		t.Fatal(err)
+	}
+	if got := pickedOutbound(t, r); got != "second" {
+		t.Fatalf("selection after unrelated rule update = %q, want second", got)
+	}
+}
+
+func TestRouterReplaceRejectsUnavailableObservatory(t *testing.T) {
+	ctx := context.WithValue(context.Background(), core.XrayKey(1), new(core.Instance))
+	r := new(Router)
+	if err := r.Init(ctx, ruleSetConfig("initial", "initial-rule"), nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	version, _, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = r.ReplaceRuleSet(version, serial.ToTypedMessage(&Config{
+		BalancingRule: []*BalancingRule{{
+			Tag:      "least-ping",
+			Strategy: "leastPing",
+		}},
+	}))
+	if err == nil {
+		t.Fatal("replacement without Observatory succeeded")
+	}
+	current, _, getErr := r.GetRuleSet()
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if current != version {
+		t.Fatalf("version changed after dependency failure: got %+v, want %+v", current, version)
+	}
+}
+
+func TestRouterConcurrentSnapshotAccess(t *testing.T) {
+	manager := &staticOutboundManager{}
+	r := new(Router)
+	config := balancedRuleSetConfig()
+	if err := r.Init(context.Background(), config, nil, manager, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	var (
+		wg       sync.WaitGroup
+		errOnce  sync.Once
+		firstErr error
+	)
+	recordError := func(err error) {
+		if err != nil {
+			errOnce.Do(func() {
+				firstErr = err
+			})
+		}
+	}
+
+	const (
+		readerCount = 8
+		iterations  = 100
+	)
+	for range readerCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				if _, err := r.PickRoute(tcpRoutingContext()); err != nil {
+					recordError(err)
+					return
+				}
+				if len(r.ListRule()) != 1 {
+					recordError(stderrors.New("unexpected rule count"))
+					return
+				}
+				if _, _, err := r.GetRuleSet(); err != nil {
+					recordError(err)
+					return
+				}
+				if err := r.SetOverrideTarget("balance", ""); err != nil {
+					recordError(err)
+					return
+				}
+				if _, err := r.GetOverrideTarget("balance"); err != nil {
+					recordError(err)
+					return
+				}
+				if _, err := r.GetPrincipleTarget("balance"); err != nil {
+					recordError(err)
+					return
+				}
+				if err := r.OverrideBalancer("balance", ""); err != nil {
+					recordError(err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			version, _, err := r.GetRuleSet()
+			if err != nil {
+				recordError(err)
+				return
+			}
+			if _, err := r.ReplaceRuleSet(version, serial.ToTypedMessage(config)); err != nil {
+				recordError(err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	if firstErr != nil {
+		t.Fatal(firstErr)
+	}
+}
+
+func TestRouterReturnedRouteOutlivesSnapshot(t *testing.T) {
+	r := new(Router)
+	if err := r.Init(context.Background(), ruleSetConfig("initial", "initial-rule"), nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	route, err := r.PickRoute(tcpRoutingContext())
+	if err != nil {
+		t.Fatal(err)
+	}
+	version, _, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.ReplaceRuleSet(version, serial.ToTypedMessage(ruleSetConfig("replacement", "replacement-rule"))); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := route.GetOutboundTag(); got != "initial" {
+		t.Fatalf("retired route outbound = %q, want initial", got)
+	}
+	if got := route.GetRuleTag(); got != "initial-rule" {
+		t.Fatalf("retired route rule tag = %q, want initial-rule", got)
+	}
+}
+
+func TestRouterReplaceWaitsForRetiredWebhook(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+	}))
+	defer server.Close()
+
+	initial := ruleSetConfig("initial", "initial-rule")
+	initial.Rule[0].Webhook = &WebhookConfig{Url: server.URL}
+	r := new(Router)
+	if err := r.Init(context.Background(), initial, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	version, _, err := r.GetRuleSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.PickRoute(tcpRoutingContext()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("webhook request did not start")
+	}
+
+	replaceResult := make(chan error, 1)
+	go func() {
+		_, err := r.ReplaceRuleSet(version, serial.ToTypedMessage(ruleSetConfig("replacement", "replacement-rule")))
+		replaceResult <- err
+	}()
+
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		current, _, err := r.GetRuleSet()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if current.Generation == version.Generation+1 {
+			break
+		}
+		select {
+		case err := <-replaceResult:
+			t.Fatalf("replacement returned before publishing the new snapshot: %v", err)
+		case <-deadline.C:
+			t.Fatal("replacement did not publish the new snapshot")
+		case <-ticker.C:
+		}
+	}
+
+	select {
+	case err := <-replaceResult:
+		t.Fatalf("replacement returned before the retired webhook completed: %v", err)
+	default:
+	}
+	close(releaseRequest)
+	select {
+	case err := <-replaceResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("replacement did not finish after the webhook completed")
+	}
+}
+
+func ruleSetConfig(outboundTag, ruleTag string) *Config {
+	return &Config{Rule: []*RoutingRule{{
+		TargetTag: &RoutingRule_Tag{Tag: outboundTag},
+		RuleTag:   ruleTag,
+		Networks:  []net.Network{net.Network_TCP},
+	}}}
+}
+
+func balancedRuleSetConfig() *Config {
+	return &Config{
+		Rule: []*RoutingRule{{
+			TargetTag: &RoutingRule_BalancingTag{BalancingTag: "balance"},
+			RuleTag:   "balanced-rule",
+			Networks:  []net.Network{net.Network_TCP},
+		}},
+		BalancingRule: []*BalancingRule{{
+			Tag:              "balance",
+			OutboundSelector: []string{"selected"},
+		}},
+	}
+}
+
+func decodedRuleSet(t *testing.T, message *serial.TypedMessage) *Config {
+	t.Helper()
+	instance, err := message.GetInstance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, ok := instance.(*Config)
+	if !ok {
+		t.Fatalf("decoded config has type %T", instance)
+	}
+	return config
+}
+
+func pickedOutbound(t *testing.T, r *Router) string {
+	t.Helper()
+	route, err := r.PickRoute(tcpRoutingContext())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return route.GetOutboundTag()
+}
+
+func tcpRoutingContext() *routing_session.Context {
+	return &routing_session.Context{
+		Outbound: &session.Outbound{
+			Target: net.TCPDestination(net.DomainAddress("example.com"), 443),
+		},
+	}
+}

--- a/examples/external-routing/README.md
+++ b/examples/external-routing/README.md
@@ -1,0 +1,189 @@
+# External routing by authenticated VLESS user
+
+This example keeps classification inside Xray and delegates the selected
+egress path to the operating system:
+
+```text
+unknown VLESS UUID
+  -> /run/xray/auth-notifications.sock
+  -> auth daemon
+  -> /run/xray/control.sock (gRPC RoutingService.ReplaceRuleSet)
+  -> /run/xray/control.sock (gRPC HandlerService.AlterInbound/AddUser)
+  -> new VLESS connection
+  -> authenticated (inbound tag, user ID) + logical destination
+  -> Xray routing rule
+  -> outbound class
+  -> optional outbound socket mark
+  -> Linux policy routing
+```
+
+The notification and control sockets are separate. The first carries
+length-prefixed `UnknownUserAttempt` protobuf frames; the second carries gRPC.
+Xray listens on both sockets and the auth daemon connects to both.
+
+## Authentication flow
+
+The example server starts with no VLESS users. When an unknown UUID connects,
+the VLESS inbound writes:
+
+```text
+uint32 big-endian protobuf length
+xray.proxy.vless.inbound.UnknownUserAttempt
+```
+
+The message contains the remote endpoint, attempted UUID, and timestamp. The
+auth daemon resolves that credential in its own backend and calls:
+
+```text
+HandlerService.AlterInbound(
+  tag = "vless-in",
+  operation = AddUserOperation(
+    user.email = canonical opaque user ID,
+    user.account = VLESS account
+  )
+)
+```
+
+The connection that produced the notification has already failed
+authentication. `AddUser` cannot revive it; the client must establish a new
+physical VLESS connection. Client retry can be automatic, but the server-side
+contract remains reject-then-add-then-reconnect.
+
+Use a non-empty canonical opaque database ID in `user.email`; do not put the
+bearer UUID there. Routing identity is the pair `(inboundTag, user)`, so every
+per-user rule in this example contains both fields.
+
+This fork deliberately ignores UUID bytes 6 and 7 during VLESS lookup and
+exposes those client-controlled bytes as `vlessRoute`. An auth daemon must
+normalize those bytes before backend lookup. `vlessRoute` is not trusted user
+identity.
+
+`AddUser` is an in-memory, non-idempotent operation. The daemon must:
+
+- singleflight provisioning by normalized credential;
+- prevent two user IDs from claiming the same normalized UUID;
+- reconcile ambiguous RPC results with `GetInboundUsers`;
+- replay users and routing desired state after Xray restarts.
+
+## Routing control plane
+
+Rules are evaluated in order and conditions inside one rule are combined with
+AND. The first example rule means:
+
+```text
+inbound vless-in
+AND user client-42
+AND configured Russian-service domain
+-> ru-system
+```
+
+The user fallback must remain after the more specific Russian-service rule.
+The final inbound-wide rule sends any VLESS user without an installed policy
+to `deny`. `deny` is also the first outbound, so a malformed or incomplete
+replacement remains fail-closed.
+
+Infrastructure can keep these rules in the static config or manage the full
+desired rule set through `RoutingService` on the same Commander Unix socket.
+For live updates use:
+
+1. `GetRuleSet`
+2. build a complete ordered desired state
+3. `ReplaceRuleSet(expected_version, config)`
+
+`GetRuleSet` returns only the version unless `include_config` is true. A
+controller that owns desired state should use the version-only form. If the
+controller must read a large live config, its gRPC client also needs a matching
+receive limit (for grpc-go, `grpc.MaxCallRecvMsgSize`).
+
+The version contains an Xray instance ID and generation. Replacement is
+compare-and-swap: a stale controller receives a conflict, and an invalid
+candidate leaves the live rules unchanged. The legacy per-rule mutation RPCs
+remain for compatibility but are implemented through the same copy-on-write
+state.
+
+The example raises Commander's receive/send limits to 16 MiB for full
+rule-set replacement. Set explicit limits appropriate for the maximum desired
+state; leaving them at zero keeps the gRPC defaults.
+
+Treat a successful `GetRuleSet` as the rollout capability check. An older core
+returns gRPC `UNIMPLEMENTED` for the new RPC and must not be provisioned as if
+it supported atomic policy updates.
+
+For a new dynamic user, install its routing desired state before calling
+`AddUser`. For revocation, first replace the user's policy with an explicit
+`deny` tombstone and then remove the user. Keep the tombstone until all
+pre-existing connections have expired: removing a validator entry does not
+terminate an already authenticated mux connection.
+
+If infrastructure creates per-user outbound classes dynamically, add the
+outbound through `HandlerService.AddOutbound` before publishing rules that
+reference it. Remove it only after the deny/remove/drain sequence.
+
+## Mux behavior
+
+Mux and connection reuse are unchanged. A single authenticated physical VLESS
+connection can carry several logical streams. Every inner stream retains the
+authenticated user and its own destination, so Xray can route two simultaneous
+destinations to different outbound classes without splitting the inbound mux
+connection.
+
+The regression scenario proves the complete path:
+
+```bash
+go test ./testing/scenarios \
+  -run '^TestVlessMuxUserDestinationRouting$' \
+  -count=1
+```
+
+It starts Xray with an empty VLESS user set, consumes the notification socket,
+updates the rule snapshot and calls the real proxyman `AddUser` RPC over a
+second Unix socket. It verifies that the unknown connection fails, the retry
+succeeds, two concurrent logical mux streams reach different backends, and
+only one new post-auth physical VLESS connection is created.
+
+Unknown-user attempts are not retained while no notification client is
+connected. Start the auth daemon and confirm both Unix-socket connections
+before exposing the VLESS listener, and keep client reconnect/retry enabled.
+This avoids storing bearer credentials in an unbounded offline queue.
+
+## System routing
+
+`ru-system` sets mark `100`. Xray selects the outbound class and applies the
+mark to the outbound socket; Linux interprets it:
+
+```bash
+sudo ip route add default via <RU_GATEWAY> dev <RU_INTERFACE> table 100
+sudo ip rule add priority 100 fwmark 100 lookup 100
+
+sudo ip -6 route add default via <RU_IPV6_GATEWAY> dev <RU_INTERFACE> table 100
+sudo ip -6 rule add priority 100 fwmark 100 lookup 100
+```
+
+Applying `SO_MARK` normally requires `CAP_NET_ADMIN`; supported kernels may
+also permit `CAP_NET_RAW`. Socket options keep Xray's existing best-effort
+behavior: an application error is logged and the connection may use the
+default route. Deployment checks must verify the effective mark and Linux
+policy-routing rules before serving traffic.
+
+## Example configuration
+
+Validate the client sample on any supported host and the server sample on
+Linux. The server sample intentionally relies on Linux `SO_MARK`:
+
+```bash
+xray run -test -config examples/external-routing/client.json
+# Linux:
+xray run -test -config examples/external-routing/server.json
+```
+
+The server paths assume a root-created `/run/xray` directory with mode `0700`
+and ownership assigned to the Xray service account. Both sockets use mode
+`0600`. Commander has no independent
+authentication layer, so filesystem ownership and permissions are the
+control-plane security boundary; do not use an abstract or network-exposed
+socket for this API.
+
+The sample domain list is illustrative. Infrastructure is responsible for
+maintaining production domain and CIDR data. If Xray receives only an IP
+destination, a domain rule can match only when sniffing recovers a hostname;
+use maintained IP rules for traffic that must be classified without one.

--- a/examples/external-routing/client.json
+++ b/examples/external-routing/client.json
@@ -1,0 +1,44 @@
+{
+  "log": {
+    "loglevel": "info"
+  },
+  "inbounds": [
+    {
+      "tag": "local-socks",
+      "listen": "127.0.0.1",
+      "port": 1080,
+      "protocol": "socks",
+      "settings": {
+        "auth": "noauth",
+        "udp": true
+      }
+    }
+  ],
+  "outbounds": [
+    {
+      "tag": "vless-server",
+      "protocol": "vless",
+      "settings": {
+        "vnext": [
+          {
+            "address": "127.0.0.1",
+            "port": 10443,
+            "users": [
+              {
+                "id": "11111111-1111-4111-8111-111111111111",
+                "encryption": "none"
+              }
+            ]
+          }
+        ]
+      },
+      "streamSettings": {
+        "network": "tcp"
+      },
+      "mux": {
+        "enabled": true,
+        "concurrency": 8
+      }
+    }
+  ]
+}

--- a/examples/external-routing/server.json
+++ b/examples/external-routing/server.json
@@ -1,0 +1,98 @@
+{
+  "log": {
+    "loglevel": "info"
+  },
+  "api": {
+    "tag": "api",
+    "listen": "/run/xray/control.sock,0600",
+    "maxReceiveMessageSize": 16777216,
+    "maxSendMessageSize": 16777216,
+    "services": [
+      "HandlerService",
+      "RoutingService"
+    ]
+  },
+  "inbounds": [
+    {
+      "tag": "vless-in",
+      "listen": "127.0.0.1",
+      "port": 10443,
+      "protocol": "vless",
+      "settings": {
+        "clients": [],
+        "notifications": "/run/xray/auth-notifications.sock",
+        "decryption": "none"
+      },
+      "sniffing": {
+        "enabled": true,
+        "destOverride": [
+          "http",
+          "tls",
+          "quic"
+        ],
+        "routeOnly": true
+      }
+    }
+  ],
+  "outbounds": [
+    {
+      "tag": "deny",
+      "protocol": "blackhole",
+      "settings": {}
+    },
+    {
+      "tag": "default-system",
+      "protocol": "freedom",
+      "settings": {}
+    },
+    {
+      "tag": "ru-system",
+      "protocol": "freedom",
+      "settings": {},
+      "streamSettings": {
+        "sockopt": {
+          "mark": 100
+        }
+      }
+    }
+  ],
+  "routing": {
+    "domainStrategy": "AsIs",
+    "rules": [
+      {
+        "type": "field",
+        "ruleTag": "client-42-ru",
+        "inboundTag": [
+          "vless-in"
+        ],
+        "user": [
+          "client-42"
+        ],
+        "domain": [
+          "domain:gosuslugi.ru",
+          "domain:nalog.gov.ru"
+        ],
+        "outboundTag": "ru-system"
+      },
+      {
+        "type": "field",
+        "ruleTag": "client-42-default",
+        "inboundTag": [
+          "vless-in"
+        ],
+        "user": [
+          "client-42"
+        ],
+        "outboundTag": "default-system"
+      },
+      {
+        "type": "field",
+        "ruleTag": "unprovisioned-vless-deny",
+        "inboundTag": [
+          "vless-in"
+        ],
+        "outboundTag": "deny"
+      }
+    ]
+  }
+}

--- a/infra/conf/api.go
+++ b/infra/conf/api.go
@@ -14,14 +14,19 @@ import (
 )
 
 type APIConfig struct {
-	Tag      string   `json:"tag"`
-	Listen   string   `json:"listen"`
-	Services []string `json:"services"`
+	Tag                   string   `json:"tag"`
+	Listen                string   `json:"listen"`
+	Services              []string `json:"services"`
+	MaxReceiveMessageSize int32    `json:"maxReceiveMessageSize"`
+	MaxSendMessageSize    int32    `json:"maxSendMessageSize"`
 }
 
 func (c *APIConfig) Build() (*commander.Config, error) {
 	if c.Tag == "" {
 		return nil, errors.New("API tag can't be empty.")
+	}
+	if c.MaxReceiveMessageSize < 0 || c.MaxSendMessageSize < 0 {
+		return nil, errors.New("API gRPC message sizes must not be negative.")
 	}
 
 	services := make([]*serial.TypedMessage, 0, 16)
@@ -43,8 +48,10 @@ func (c *APIConfig) Build() (*commander.Config, error) {
 	}
 
 	return &commander.Config{
-		Tag:     c.Tag,
-		Listen:  c.Listen,
-		Service: services,
+		Tag:                   c.Tag,
+		Listen:                c.Listen,
+		Service:               services,
+		MaxReceiveMessageSize: c.MaxReceiveMessageSize,
+		MaxSendMessageSize:    c.MaxSendMessageSize,
 	}, nil
 }

--- a/infra/conf/api_test.go
+++ b/infra/conf/api_test.go
@@ -1,0 +1,35 @@
+package conf
+
+import "testing"
+
+func TestAPIConfigBuildsGRPCMessageLimits(t *testing.T) {
+	const (
+		maxReceive = int32(16 * 1024 * 1024)
+		maxSend    = int32(8 * 1024 * 1024)
+	)
+	config, err := (&APIConfig{
+		Tag:                   "api",
+		MaxReceiveMessageSize: maxReceive,
+		MaxSendMessageSize:    maxSend,
+	}).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.GetMaxReceiveMessageSize() != maxReceive {
+		t.Fatalf("max receive size = %d, want %d", config.GetMaxReceiveMessageSize(), maxReceive)
+	}
+	if config.GetMaxSendMessageSize() != maxSend {
+		t.Fatalf("max send size = %d, want %d", config.GetMaxSendMessageSize(), maxSend)
+	}
+}
+
+func TestAPIConfigRejectsNegativeGRPCMessageLimits(t *testing.T) {
+	for _, config := range []*APIConfig{
+		{Tag: "api", MaxReceiveMessageSize: -1},
+		{Tag: "api", MaxSendMessageSize: -1},
+	} {
+		if _, err := config.Build(); err == nil {
+			t.Fatalf("negative gRPC message limit was accepted: %+v", config)
+		}
+	}
+}

--- a/proxy/vless/inbound/inbound.go
+++ b/proxy/vless/inbound/inbound.go
@@ -5,13 +5,10 @@ import (
 	"context"
 	gotls "crypto/tls"
 	"encoding/base64"
-	"encoding/binary"
 	"io"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 	"unsafe"
 
@@ -47,7 +44,6 @@ import (
 	"github.com/xtls/xray-core/transport/internet/reality"
 	"github.com/xtls/xray-core/transport/internet/stat"
 	"github.com/xtls/xray-core/transport/internet/tls"
-	"google.golang.org/protobuf/proto"
 )
 
 func init() {
@@ -89,11 +85,7 @@ type Handler struct {
 	defaultDispatcher      routing.Dispatcher
 	ctx                    context.Context
 	fallbacks              map[string]map[string]map[string]*Fallback // or nil
-	clientConnections      map[net.Conn]struct{}
-	notifiedInvalidIDs     map[string]time.Time
-	clientMutex            sync.Mutex
-	notificationMutex      sync.Mutex
-	unixListener           net.Listener
+	unknownUserNotifier    *unknownUserNotifier
 	// regexps               map[string]*regexp.Regexp       // or nil
 }
 
@@ -109,8 +101,6 @@ func New(ctx context.Context, config *Config, dc dns.Client, validator vless.Val
 		observer:               v.GetFeature(extension.ObservatoryType()),
 		defaultDispatcher:      v.GetFeature(routing.DispatcherType()).(routing.Dispatcher),
 		ctx:                    ctx,
-		clientConnections:      make(map[net.Conn]struct{}),
-		notifiedInvalidIDs:     make(map[string]time.Time),
 	}
 
 	if config.Decryption != "" && config.Decryption != "none" {
@@ -187,23 +177,11 @@ func New(ctx context.Context, config *Config, dc dns.Client, validator vless.Val
 	}
 
 	if socketPath := config.Notifications; socketPath != "" {
-		if _, err := os.Stat(socketPath); err == nil {
-			_ = os.Remove(socketPath)
-		}
-
-		listener, err := net.Listen("unix", socketPath)
+		notifier, err := newUnknownUserNotifier(ctx, socketPath)
 		if err != nil {
-			errors.LogErrorInner(ctx, err, "error setting up UNIX domain socket listener")
 			return nil, err
 		}
-
-		if err := os.Chmod(socketPath, 0o600); err != nil {
-			_ = listener.Close()
-			return nil, errors.New("failed to chmod UNIX domain socket").Base(err)
-		}
-
-		handler.unixListener = listener
-		go handler.acceptUnixSocketClients(ctx)
+		handler.unknownUserNotifier = notifier
 	}
 
 	return handler, nil
@@ -265,14 +243,9 @@ func (h *Handler) Close() error {
 	for _, u := range h.validator.GetAll() {
 		h.RemoveReverse(u)
 	}
-	h.clientMutex.Lock()
 	var closeErrs []error
-	for clientConn := range h.clientConnections {
-		closeErrs = append(closeErrs, clientConn.Close())
-	}
-	h.clientMutex.Unlock()
-	if h.unixListener != nil {
-		closeErrs = append(closeErrs, h.unixListener.Close())
+	if h.unknownUserNotifier != nil {
+		closeErrs = append(closeErrs, h.unknownUserNotifier.Close())
 	}
 	closeErrs = append(closeErrs, common.Close(h.validator))
 	return errors.Combine(closeErrs...)
@@ -348,9 +321,11 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 
 	if isfb && firstLen < 18 {
 		err = errors.New("fallback directly")
+	} else if h.unknownUserNotifier == nil {
+		userSentID, request, requestAddons, isfb, err = encoding.DecodeRequestHeader(isfb, first, reader, h.validator)
 	} else {
 		notifyInvalidUserIDCallback := func(userID uuid.UUID) {
-			h.notifyUnknownUserAttempt(ctx, connection, userID)
+			h.unknownUserNotifier.Notify(ctx, connection.RemoteAddr(), userID)
 		}
 		userSentID, request, requestAddons, isfb, err = encoding.DecodeRequestHeader(isfb, first, reader, h.validator, notifyInvalidUserIDCallback)
 	}
@@ -742,91 +717,4 @@ func (r *Reverse) SenderSettings() *serial.TypedMessage {
 
 func (r *Reverse) ProxySettings() *serial.TypedMessage {
 	return nil
-}
-
-func (h *Handler) acceptUnixSocketClients(ctx context.Context) {
-	for {
-		conn, err := h.unixListener.Accept()
-		if err != nil {
-			errors.LogDebugInner(ctx, err, "error accepting UNIX socket connection")
-			return
-		}
-		errors.LogDebug(ctx, "connected notifications UNIX socket")
-
-		h.clientMutex.Lock()
-		h.clientConnections[conn] = struct{}{}
-		h.clientMutex.Unlock()
-
-		go h.handleUnixSocketClient(ctx, conn)
-	}
-}
-
-func (h *Handler) handleUnixSocketClient(ctx context.Context, conn net.Conn) {
-	defer conn.Close()
-	buffer := make([]byte, 1)
-
-	for {
-		if _, err := conn.Read(buffer); err != nil {
-			h.clientMutex.Lock()
-			delete(h.clientConnections, conn)
-			h.clientMutex.Unlock()
-			if err != io.EOF {
-				errors.LogErrorInner(ctx, err, "error reading from client")
-			}
-			return
-		}
-	}
-}
-
-func (h *Handler) notifyUnknownUserAttempt(ctx context.Context, conn net.Conn, attemptedUUID uuid.UUID) {
-	attemptedUUIDStr := attemptedUUID.String()
-	currentTime := time.Now()
-
-	h.notificationMutex.Lock()
-	uuidTime, exists := h.notifiedInvalidIDs[attemptedUUIDStr]
-	if !exists || uuidTime.Before(currentTime.Add(-30*time.Second)) {
-		h.notifiedInvalidIDs[attemptedUUIDStr] = currentTime
-		h.notificationMutex.Unlock()
-	} else {
-		h.notificationMutex.Unlock()
-		return
-	}
-
-	remoteAddr := conn.RemoteAddr()
-	var remoteIP string
-	var remotePort int
-	if tcpAddr, ok := remoteAddr.(*net.TCPAddr); ok {
-		remoteIP = tcpAddr.IP.String()
-		remotePort = tcpAddr.Port
-	} else {
-		remoteIP = remoteAddr.String()
-	}
-
-	attempt := &UnknownUserAttempt{
-		RemoteIp:      remoteIP,
-		RemotePort:    int32(remotePort),
-		AttemptedUuid: attemptedUUIDStr,
-		Timestamp:     currentTime.Unix(),
-	}
-
-	data, err := proto.Marshal(attempt)
-	if err != nil {
-		errors.LogErrorInner(ctx, err, "error marshalling protobuf message")
-		return
-	}
-	lengthBuf := make([]byte, 4)
-	binary.BigEndian.PutUint32(lengthBuf, uint32(len(data)))
-	message := append(lengthBuf, data...)
-
-	h.clientMutex.Lock()
-	defer h.clientMutex.Unlock()
-
-	for clientConn := range h.clientConnections {
-		errors.LogDebug(ctx, "writing data to UNIX socket client connection")
-		if _, err := clientConn.Write(message); err != nil {
-			errors.LogErrorInner(ctx, err, "error writing to client")
-			_ = clientConn.Close()
-			delete(h.clientConnections, clientConn)
-		}
-	}
 }

--- a/proxy/vless/inbound/notifications.go
+++ b/proxy/vless/inbound/notifications.go
@@ -1,0 +1,665 @@
+package inbound
+
+import (
+	"container/list"
+	"context"
+	"encoding/binary"
+	stderrors "errors"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/uuid"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	defaultNotificationDedupTTL        = 30 * time.Second
+	defaultNotificationDedupEntries    = 4096
+	defaultNotificationEventQueueSize  = 256
+	defaultNotificationClientQueueSize = 32
+	defaultNotificationMaxClients      = 8
+	defaultNotificationWriteTimeout    = 2 * time.Second
+
+	initialNotificationAcceptRetry = 5 * time.Millisecond
+	maxNotificationAcceptRetry     = time.Second
+	notificationSocketProbeTimeout = 100 * time.Millisecond
+)
+
+type unknownUserNotifierOptions struct {
+	dedupTTL        time.Duration
+	dedupEntries    int
+	eventQueueSize  int
+	clientQueueSize int
+	maxClients      int
+	writeTimeout    time.Duration
+	now             func() time.Time
+}
+
+func defaultUnknownUserNotifierOptions() unknownUserNotifierOptions {
+	return unknownUserNotifierOptions{
+		dedupTTL:        defaultNotificationDedupTTL,
+		dedupEntries:    defaultNotificationDedupEntries,
+		eventQueueSize:  defaultNotificationEventQueueSize,
+		clientQueueSize: defaultNotificationClientQueueSize,
+		maxClients:      defaultNotificationMaxClients,
+		writeTimeout:    defaultNotificationWriteTimeout,
+		now:             time.Now,
+	}
+}
+
+func (o unknownUserNotifierOptions) validate() error {
+	switch {
+	case o.dedupTTL <= 0:
+		return errors.New("notification deduplication TTL must be positive")
+	case o.dedupEntries <= 0:
+		return errors.New("notification deduplication capacity must be positive")
+	case o.eventQueueSize <= 0:
+		return errors.New("notification event queue size must be positive")
+	case o.clientQueueSize <= 0:
+		return errors.New("notification client queue size must be positive")
+	case o.maxClients <= 0:
+		return errors.New("notification client limit must be positive")
+	case o.writeTimeout <= 0:
+		return errors.New("notification write timeout must be positive")
+	case o.now == nil:
+		return errors.New("notification clock must not be nil")
+	default:
+		return nil
+	}
+}
+
+type unknownUserNotification struct {
+	key   string
+	token uint64
+	frame []byte
+}
+
+type unknownUserNotificationDelivery struct {
+	notifier     *unknownUserNotifier
+	notification unknownUserNotification
+	pending      atomic.Int32
+	succeeded    atomic.Bool
+}
+
+func newUnknownUserNotificationDelivery(
+	notifier *unknownUserNotifier,
+	notification unknownUserNotification,
+) *unknownUserNotificationDelivery {
+	delivery := &unknownUserNotificationDelivery{
+		notifier:     notifier,
+		notification: notification,
+	}
+	// The broadcaster owns one reference until it has finished enqueueing the
+	// delivery. This prevents a fast writer from completing before all client
+	// references have been registered.
+	delivery.pending.Store(1)
+	return delivery
+}
+
+func (d *unknownUserNotificationDelivery) addRecipient() {
+	d.pending.Add(1)
+}
+
+func (d *unknownUserNotificationDelivery) complete(succeeded bool) {
+	if succeeded {
+		d.succeeded.Store(true)
+	}
+	if d.pending.Add(-1) == 0 && !d.succeeded.Load() {
+		// A full UDS write is the strongest delivery signal available without
+		// changing the existing one-way wire protocol to require acknowledgements.
+		d.notifier.dedup.Forget(d.notification.key, d.notification.token)
+	}
+}
+
+type unknownUserNotificationClient struct {
+	conn      net.Conn
+	queue     chan *unknownUserNotificationDelivery
+	done      chan struct{}
+	closeOnce sync.Once
+	mu        sync.Mutex
+	closing   bool
+}
+
+func (c *unknownUserNotificationClient) Close() {
+	c.closeOnce.Do(func() {
+		c.mu.Lock()
+		c.closing = true
+		close(c.done)
+		c.mu.Unlock()
+		_ = c.conn.Close()
+	})
+}
+
+func (c *unknownUserNotificationClient) tryEnqueue(
+	delivery *unknownUserNotificationDelivery,
+) (queued bool, full bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closing {
+		return false, false
+	}
+	select {
+	case c.queue <- delivery:
+		return true, false
+	default:
+		return false, true
+	}
+}
+
+func (c *unknownUserNotificationClient) closed() bool {
+	select {
+	case <-c.done:
+		return true
+	default:
+		return false
+	}
+}
+
+type unknownUserNotifier struct {
+	ctx      context.Context
+	listener net.Listener
+	options  unknownUserNotifierOptions
+
+	done      chan struct{}
+	closeOnce sync.Once
+	closeErr  error
+	wg        sync.WaitGroup
+
+	clientsMu   sync.Mutex
+	clients     map[*unknownUserNotificationClient]struct{}
+	closing     bool
+	clientCount atomic.Int32
+
+	events chan unknownUserNotification
+	dedup  *unknownUserNotificationDeduplicator
+}
+
+func newUnknownUserNotifier(ctx context.Context, socketPath string) (*unknownUserNotifier, error) {
+	return newUnknownUserNotifierWithOptions(ctx, socketPath, defaultUnknownUserNotifierOptions())
+}
+
+func newUnknownUserNotifierWithOptions(
+	ctx context.Context,
+	socketPath string,
+	options unknownUserNotifierOptions,
+) (*unknownUserNotifier, error) {
+	if socketPath == "" {
+		return nil, nil
+	}
+	if err := options.validate(); err != nil {
+		return nil, err
+	}
+
+	listener, err := listenUnknownUserNotifications(socketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	notifier := newUnknownUserNotifierState(ctx, listener, options)
+	notifier.wg.Add(2)
+	go notifier.acceptClients()
+	go notifier.broadcast()
+	return notifier, nil
+}
+
+func newUnknownUserNotifierState(
+	ctx context.Context,
+	listener net.Listener,
+	options unknownUserNotifierOptions,
+) *unknownUserNotifier {
+	return &unknownUserNotifier{
+		ctx:      ctx,
+		listener: listener,
+		options:  options,
+		done:     make(chan struct{}),
+		clients:  make(map[*unknownUserNotificationClient]struct{}),
+		events:   make(chan unknownUserNotification, options.eventQueueSize),
+		dedup:    newUnknownUserNotificationDeduplicator(options.dedupTTL, options.dedupEntries),
+	}
+}
+
+func listenUnknownUserNotifications(socketPath string) (net.Listener, error) {
+	if strings.HasPrefix(socketPath, "@") {
+		return nil, errors.New("VLESS notification socket requires a filesystem path")
+	}
+
+	info, err := os.Lstat(socketPath)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSocket == 0 {
+			return nil, errors.New("refusing to replace non-socket notification path: ", socketPath)
+		}
+		if err := removeStaleUnknownUserNotificationSocket(socketPath); err != nil {
+			return nil, err
+		}
+	case stderrors.Is(err, os.ErrNotExist):
+	default:
+		return nil, errors.New("failed to inspect notification socket path").Base(err)
+	}
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, errors.New("failed to listen on notification UNIX socket").Base(err)
+	}
+	if unixListener, ok := listener.(*net.UnixListener); ok {
+		unixListener.SetUnlinkOnClose(true)
+	}
+	if err := os.Chmod(socketPath, 0o600); err != nil {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+		return nil, errors.New("failed to chmod notification UNIX socket").Base(err)
+	}
+	return listener, nil
+}
+
+func removeStaleUnknownUserNotificationSocket(socketPath string) error {
+	conn, err := net.DialTimeout("unix", socketPath, notificationSocketProbeTimeout)
+	if err == nil {
+		_ = conn.Close()
+		return errors.New("notification UNIX socket is already in use: ", socketPath)
+	}
+	if !isNotificationSocketConnectionRefused(err) && !stderrors.Is(err, os.ErrNotExist) {
+		return errors.New("failed to verify existing notification UNIX socket is stale").Base(err)
+	}
+	if err := os.Remove(socketPath); err != nil && !stderrors.Is(err, os.ErrNotExist) {
+		return errors.New("failed to remove stale notification socket").Base(err)
+	}
+	return nil
+}
+
+func (n *unknownUserNotifier) Notify(ctx context.Context, remoteAddr net.Addr, attemptedUUID uuid.UUID) {
+	if n == nil || n.clientCount.Load() == 0 || n.closed() {
+		return
+	}
+
+	now := n.options.now()
+	key := attemptedUUID.String()
+	token, allowed := n.dedup.Reserve(key, now)
+	if !allowed {
+		return
+	}
+
+	frame, err := marshalUnknownUserNotification(remoteAddr, key, now)
+	if err != nil {
+		n.dedup.Forget(key, token)
+		errors.LogErrorInner(ctx, err, "error marshalling unknown VLESS user notification")
+		return
+	}
+
+	event := unknownUserNotification{
+		key:   key,
+		token: token,
+		frame: frame,
+	}
+	select {
+	case n.events <- event:
+	case <-n.done:
+		n.dedup.Forget(key, token)
+	default:
+		n.dedup.Forget(key, token)
+	}
+}
+
+func marshalUnknownUserNotification(remoteAddr net.Addr, attemptedUUID string, now time.Time) ([]byte, error) {
+	var remoteIP string
+	var remotePort int32
+	switch addr := remoteAddr.(type) {
+	case *net.TCPAddr:
+		remoteIP = addr.IP.String()
+		remotePort = int32(addr.Port)
+	case nil:
+	default:
+		remoteIP = addr.String()
+	}
+
+	payload, err := proto.Marshal(&UnknownUserAttempt{
+		RemoteIp:      remoteIP,
+		RemotePort:    remotePort,
+		AttemptedUuid: attemptedUUID,
+		Timestamp:     now.Unix(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	frame := make([]byte, 4+len(payload))
+	binary.BigEndian.PutUint32(frame[:4], uint32(len(payload)))
+	copy(frame[4:], payload)
+	return frame, nil
+}
+
+func (n *unknownUserNotifier) acceptClients() {
+	defer n.wg.Done()
+
+	retryDelay := initialNotificationAcceptRetry
+	for {
+		conn, err := n.listener.Accept()
+		if err == nil {
+			retryDelay = initialNotificationAcceptRetry
+			n.addClient(conn)
+			continue
+		}
+		if n.closed() {
+			return
+		}
+
+		errors.LogDebugInner(n.ctx, err, "error accepting notification UNIX socket connection")
+		timer := time.NewTimer(retryDelay)
+		select {
+		case <-timer.C:
+		case <-n.done:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return
+		}
+		retryDelay *= 2
+		if retryDelay > maxNotificationAcceptRetry {
+			retryDelay = maxNotificationAcceptRetry
+		}
+	}
+}
+
+func (n *unknownUserNotifier) addClient(conn net.Conn) bool {
+	client := &unknownUserNotificationClient{
+		conn:  conn,
+		queue: make(chan *unknownUserNotificationDelivery, n.options.clientQueueSize),
+		done:  make(chan struct{}),
+	}
+
+	n.clientsMu.Lock()
+	if n.closing || len(n.clients) >= n.options.maxClients {
+		n.clientsMu.Unlock()
+		client.Close()
+		return false
+	}
+	n.clients[client] = struct{}{}
+	n.clientCount.Add(1)
+	n.wg.Add(2)
+	n.clientsMu.Unlock()
+
+	go n.writeClient(client)
+	go n.watchClient(client)
+	return true
+}
+
+func (n *unknownUserNotifier) writeClient(client *unknownUserNotificationClient) {
+	defer n.wg.Done()
+	defer func() {
+		n.removeClient(client)
+		n.failQueuedDeliveries(client)
+	}()
+
+	for {
+		select {
+		case delivery := <-client.queue:
+			frameWritten, err := writeNotificationFrame(
+				client.conn,
+				delivery.notification.frame,
+				n.options.writeTimeout,
+				n.options.now,
+			)
+			delivery.complete(frameWritten)
+			if err != nil {
+				if !n.closed() {
+					errors.LogDebugInner(n.ctx, err, "error writing to notification UNIX socket client")
+				}
+				return
+			}
+		case <-client.done:
+			return
+		case <-n.done:
+			return
+		}
+	}
+}
+
+func (*unknownUserNotifier) failQueuedDeliveries(client *unknownUserNotificationClient) {
+	for {
+		select {
+		case delivery := <-client.queue:
+			delivery.complete(false)
+		default:
+			return
+		}
+	}
+}
+
+func (n *unknownUserNotifier) watchClient(client *unknownUserNotificationClient) {
+	defer n.wg.Done()
+	defer n.removeClient(client)
+
+	buffer := make([]byte, 1)
+	for {
+		if _, err := client.conn.Read(buffer); err != nil {
+			return
+		}
+	}
+}
+
+func writeNotificationFrame(
+	conn net.Conn,
+	frame []byte,
+	timeout time.Duration,
+	now func() time.Time,
+) (frameWritten bool, err error) {
+	if err := conn.SetWriteDeadline(now().Add(timeout)); err != nil {
+		return false, err
+	}
+	defer func() {
+		if clearErr := conn.SetWriteDeadline(time.Time{}); err == nil && clearErr != nil {
+			err = clearErr
+		}
+	}()
+
+	for len(frame) > 0 {
+		written, writeErr := conn.Write(frame)
+		if written < 0 || written > len(frame) {
+			return false, io.ErrShortWrite
+		}
+		if written > 0 {
+			frame = frame[written:]
+		}
+		if writeErr != nil {
+			return len(frame) == 0, writeErr
+		}
+		if written == 0 {
+			return false, io.ErrShortWrite
+		}
+	}
+	return true, nil
+}
+
+func (n *unknownUserNotifier) broadcast() {
+	defer n.wg.Done()
+
+	for {
+		select {
+		case event := <-n.events:
+			delivery := newUnknownUserNotificationDelivery(n, event)
+			for _, client := range n.clientSnapshot() {
+				if client.closed() {
+					continue
+				}
+				delivery.addRecipient()
+				queued, full := client.tryEnqueue(delivery)
+				if !queued {
+					delivery.complete(false)
+				}
+				if full {
+					n.removeClient(client)
+				}
+			}
+			delivery.complete(false)
+		case <-n.done:
+			return
+		}
+	}
+}
+
+func (n *unknownUserNotifier) clientSnapshot() []*unknownUserNotificationClient {
+	n.clientsMu.Lock()
+	defer n.clientsMu.Unlock()
+
+	clients := make([]*unknownUserNotificationClient, 0, len(n.clients))
+	for client := range n.clients {
+		clients = append(clients, client)
+	}
+	return clients
+}
+
+func (n *unknownUserNotifier) removeClient(client *unknownUserNotificationClient) {
+	n.clientsMu.Lock()
+	_, found := n.clients[client]
+	if found {
+		delete(n.clients, client)
+		n.clientCount.Add(-1)
+	}
+	n.clientsMu.Unlock()
+
+	if found {
+		client.Close()
+	}
+}
+
+func (n *unknownUserNotifier) closed() bool {
+	select {
+	case <-n.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (n *unknownUserNotifier) Close() error {
+	if n == nil {
+		return nil
+	}
+
+	n.closeOnce.Do(func() {
+		n.clientsMu.Lock()
+		n.closing = true
+		clients := make([]*unknownUserNotificationClient, 0, len(n.clients))
+		for client := range n.clients {
+			clients = append(clients, client)
+			delete(n.clients, client)
+		}
+		n.clientCount.Store(0)
+		n.clientsMu.Unlock()
+
+		close(n.done)
+		if n.listener != nil {
+			if err := n.listener.Close(); err != nil && !stderrors.Is(err, net.ErrClosed) {
+				n.closeErr = err
+			}
+		}
+		for _, client := range clients {
+			client.Close()
+		}
+		n.wg.Wait()
+	})
+	return n.closeErr
+}
+
+type unknownUserNotificationDedupEntry struct {
+	key     string
+	token   uint64
+	expires time.Time
+}
+
+type unknownUserNotificationDeduplicator struct {
+	mu       sync.Mutex
+	ttl      time.Duration
+	capacity int
+	next     uint64
+	entries  map[string]*list.Element
+	order    list.List
+}
+
+func newUnknownUserNotificationDeduplicator(
+	ttl time.Duration,
+	capacity int,
+) *unknownUserNotificationDeduplicator {
+	return &unknownUserNotificationDeduplicator{
+		ttl:      ttl,
+		capacity: capacity,
+		entries:  make(map[string]*list.Element, capacity),
+	}
+}
+
+func (d *unknownUserNotificationDeduplicator) Reserve(key string, now time.Time) (uint64, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.purgeExpired(now)
+	if element, found := d.entries[key]; found {
+		entry := element.Value.(*unknownUserNotificationDedupEntry)
+		if now.Before(entry.expires) {
+			return 0, false
+		}
+		d.remove(element)
+	}
+	for len(d.entries) >= d.capacity {
+		d.remove(d.order.Front())
+	}
+
+	d.next++
+	entry := &unknownUserNotificationDedupEntry{
+		key:     key,
+		token:   d.next,
+		expires: now.Add(d.ttl),
+	}
+	d.entries[key] = d.order.PushBack(entry)
+	return entry.token, true
+}
+
+func (d *unknownUserNotificationDeduplicator) Forget(key string, token uint64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	element, found := d.entries[key]
+	if !found {
+		return
+	}
+	entry := element.Value.(*unknownUserNotificationDedupEntry)
+	if entry.token == token {
+		d.remove(element)
+	}
+}
+
+func (d *unknownUserNotificationDeduplicator) Len() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.entries)
+}
+
+func (d *unknownUserNotificationDeduplicator) purgeExpired(now time.Time) {
+	for element := d.order.Front(); element != nil; {
+		entry := element.Value.(*unknownUserNotificationDedupEntry)
+		if now.Before(entry.expires) {
+			return
+		}
+		next := element.Next()
+		d.remove(element)
+		element = next
+	}
+}
+
+func (d *unknownUserNotificationDeduplicator) remove(element *list.Element) {
+	if element == nil {
+		return
+	}
+	entry := element.Value.(*unknownUserNotificationDedupEntry)
+	delete(d.entries, entry.key)
+	d.order.Remove(element)
+}

--- a/proxy/vless/inbound/notifications_socket_error_unix.go
+++ b/proxy/vless/inbound/notifications_socket_error_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package inbound
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isNotificationSocketConnectionRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}

--- a/proxy/vless/inbound/notifications_socket_error_windows.go
+++ b/proxy/vless/inbound/notifications_socket_error_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package inbound
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func isNotificationSocketConnectionRefused(err error) bool {
+	return errors.Is(err, windows.WSAECONNREFUSED)
+}

--- a/proxy/vless/inbound/notifications_socket_error_windows_test.go
+++ b/proxy/vless/inbound/notifications_socket_error_windows_test.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package inbound
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestIsNotificationSocketConnectionRefused(t *testing.T) {
+	err := &net.OpError{
+		Op:  "dial",
+		Net: "unix",
+		Err: &os.SyscallError{
+			Syscall: "connect",
+			Err:     windows.WSAECONNREFUSED,
+		},
+	}
+
+	if !isNotificationSocketConnectionRefused(err) {
+		t.Fatalf("wrapped WSAECONNREFUSED was not recognized: %v", err)
+	}
+	if isNotificationSocketConnectionRefused(os.ErrPermission) {
+		t.Fatal("permission error was recognized as connection refused")
+	}
+}

--- a/proxy/vless/inbound/notifications_test.go
+++ b/proxy/vless/inbound/notifications_test.go
@@ -1,0 +1,764 @@
+package inbound
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	stderrors "errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/common/uuid"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestMarshalUnknownUserNotificationFrame(t *testing.T) {
+	now := time.Unix(1_725_000_123, 987_654_321)
+	remoteAddr := &net.TCPAddr{
+		IP:   net.ParseIP("192.0.2.19"),
+		Port: 443,
+	}
+	attemptedUUID := "01234567-89ab-cdef-0123-456789abcdef"
+
+	frame, err := marshalUnknownUserNotification(remoteAddr, attemptedUUID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frame) < 4 {
+		t.Fatalf("frame is too short: %d", len(frame))
+	}
+	if got, want := int(binary.BigEndian.Uint32(frame[:4])), len(frame)-4; got != want {
+		t.Fatalf("payload length prefix = %d, want %d", got, want)
+	}
+
+	var attempt UnknownUserAttempt
+	if err := proto.Unmarshal(frame[4:], &attempt); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := attempt.GetRemoteIp(), remoteAddr.IP.String(); got != want {
+		t.Errorf("remote IP = %q, want %q", got, want)
+	}
+	if got, want := attempt.GetRemotePort(), int32(remoteAddr.Port); got != want {
+		t.Errorf("remote port = %d, want %d", got, want)
+	}
+	if got := attempt.GetAttemptedUuid(); got != attemptedUUID {
+		t.Errorf("attempted UUID = %q, want %q", got, attemptedUUID)
+	}
+	if got, want := attempt.GetTimestamp(), now.Unix(); got != want {
+		t.Errorf("timestamp = %d, want %d", got, want)
+	}
+}
+
+func TestUnknownUserNotifierDisabled(t *testing.T) {
+	notifier, err := newUnknownUserNotifierWithOptions(
+		context.Background(),
+		"",
+		defaultUnknownUserNotifierOptions(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notifier != nil {
+		t.Fatal("disabled notifications allocated notifier state")
+	}
+}
+
+func TestUnknownUserNotificationDeduplicatorBoundedTTL(t *testing.T) {
+	const capacity = 2
+	ttl := 30 * time.Second
+	now := time.Unix(1_725_000_000, 0)
+	dedup := newUnknownUserNotificationDeduplicator(ttl, capacity)
+
+	firstToken, allowed := dedup.Reserve("first", now)
+	if !allowed {
+		t.Fatal("first reservation was rejected")
+	}
+	if _, allowed := dedup.Reserve("first", now.Add(time.Second)); allowed {
+		t.Fatal("duplicate reservation was accepted before TTL")
+	}
+	if _, allowed := dedup.Reserve("second", now); !allowed {
+		t.Fatal("second key was rejected")
+	}
+	if _, allowed := dedup.Reserve("third", now); !allowed {
+		t.Fatal("third key was rejected")
+	}
+	if got := dedup.Len(); got != capacity {
+		t.Fatalf("dedup size = %d, want %d", got, capacity)
+	}
+
+	replacementToken, allowed := dedup.Reserve("first", now)
+	if !allowed {
+		t.Fatal("capacity eviction did not release oldest key")
+	}
+	dedup.Forget("first", firstToken)
+	if _, allowed := dedup.Reserve("first", now); allowed {
+		t.Fatal("stale rollback removed a newer reservation")
+	}
+	dedup.Forget("first", replacementToken)
+	if _, allowed := dedup.Reserve("first", now); !allowed {
+		t.Fatal("matching rollback did not release reservation")
+	}
+
+	if _, allowed := dedup.Reserve("expired", now.Add(ttl+time.Nanosecond)); !allowed {
+		t.Fatal("expired entries were not released")
+	}
+	if got := dedup.Len(); got > capacity {
+		t.Fatalf("dedup size = %d, exceeds capacity %d", got, capacity)
+	}
+}
+
+func TestUnknownUserNotifierDedupAndTTL(t *testing.T) {
+	options := defaultUnknownUserNotifierOptions()
+	options.dedupTTL = time.Second
+	options.writeTimeout = time.Second
+
+	var clock atomic.Int64
+	now := time.Now()
+	clock.Store(now.UnixNano())
+	options.now = func() time.Time {
+		return time.Unix(0, clock.Load())
+	}
+
+	socketPath := notificationSocketPath(t)
+	notifier, err := newUnknownUserNotifierWithOptions(context.Background(), socketPath, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := notifier.Close(); err != nil {
+			t.Errorf("close notifier: %v", err)
+		}
+	}()
+
+	client, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	waitFor(t, time.Second, func() bool {
+		return notifier.clientCount.Load() == 1
+	})
+
+	remoteAddr := &net.TCPAddr{IP: net.ParseIP("198.51.100.7"), Port: 8443}
+	attemptedUUID := mustParseUUID(t, "01234567-89ab-cdef-0123-456789abcdef")
+	notifier.Notify(context.Background(), remoteAddr, attemptedUUID)
+
+	first := readUnknownUserNotification(t, client, time.Second)
+	if got, want := first.GetAttemptedUuid(), attemptedUUID.String(); got != want {
+		t.Fatalf("attempted UUID = %q, want %q", got, want)
+	}
+	if got, want := first.GetRemoteIp(), remoteAddr.IP.String(); got != want {
+		t.Fatalf("remote IP = %q, want %q", got, want)
+	}
+	if got, want := first.GetRemotePort(), int32(remoteAddr.Port); got != want {
+		t.Fatalf("remote port = %d, want %d", got, want)
+	}
+
+	notifier.Notify(context.Background(), remoteAddr, attemptedUUID)
+	expectNoNotification(t, client, 30*time.Millisecond)
+
+	clock.Add(int64(options.dedupTTL + time.Nanosecond))
+	notifier.Notify(context.Background(), remoteAddr, attemptedUUID)
+	second := readUnknownUserNotification(t, client, time.Second)
+	if got, want := second.GetAttemptedUuid(), attemptedUUID.String(); got != want {
+		t.Fatalf("attempted UUID after TTL = %q, want %q", got, want)
+	}
+}
+
+func TestUnknownUserNotifierQueueDropIsNonBlockingAndRetryable(t *testing.T) {
+	options := defaultUnknownUserNotifierOptions()
+	options.eventQueueSize = 1
+	notifier := newUnknownUserNotifierState(context.Background(), nil, options)
+	notifier.clientCount.Store(1)
+	defer notifier.Close()
+
+	firstUUID := mustParseUUID(t, "01234567-89ab-cdef-0123-456789abcdef")
+	droppedUUID := mustParseUUID(t, "11111111-2222-3333-4444-555555555555")
+	notifier.Notify(context.Background(), nil, firstUUID)
+
+	started := time.Now()
+	notifier.Notify(context.Background(), nil, droppedUUID)
+	if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+		t.Fatalf("Notify blocked for %s on a full event queue", elapsed)
+	}
+
+	select {
+	case <-notifier.events:
+	default:
+		t.Fatal("first event was not queued")
+	}
+
+	notifier.Notify(context.Background(), nil, droppedUUID)
+	select {
+	case event := <-notifier.events:
+		if got, want := event.key, droppedUUID.String(); got != want {
+			t.Fatalf("queued UUID = %q, want %q", got, want)
+		}
+	default:
+		t.Fatal("dropped UUID remained deduplicated after queue space became available")
+	}
+}
+
+func TestWriteNotificationFrameHandlesPartialWrites(t *testing.T) {
+	conn := &shortWriteConn{maxWrite: 3}
+	frame := []byte("length-prefixed-protobuf")
+	now := time.Unix(1_725_000_000, 0)
+	timeout := 2 * time.Second
+
+	frameWritten, err := writeNotificationFrame(conn, frame, timeout, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !frameWritten {
+		t.Fatal("full frame write was not reported")
+	}
+	if got := conn.buffer.Bytes(); !bytes.Equal(got, frame) {
+		t.Fatalf("written frame = %q, want %q", got, frame)
+	}
+	if got := len(conn.deadlines); got != 2 {
+		t.Fatalf("write deadline calls = %d, want 2", got)
+	}
+	if got, want := conn.deadlines[0], now.Add(timeout); !got.Equal(want) {
+		t.Fatalf("write deadline = %s, want %s", got, want)
+	}
+	if got := conn.deadlines[1]; !got.IsZero() {
+		t.Fatalf("write deadline was not cleared: %s", got)
+	}
+}
+
+func TestWriteNotificationFrameRejectsZeroWrite(t *testing.T) {
+	conn := &shortWriteConn{}
+	frameWritten, err := writeNotificationFrame(conn, []byte("frame"), time.Second, time.Now)
+	if frameWritten {
+		t.Fatal("zero-byte write was reported as a full frame")
+	}
+	if !stderrors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("error = %v, want %v", err, io.ErrShortWrite)
+	}
+}
+
+func TestWriteNotificationFrameTimesOut(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	started := time.Now()
+	frameWritten, err := writeNotificationFrame(server, []byte("frame"), 20*time.Millisecond, time.Now)
+	if frameWritten {
+		t.Fatal("timed-out write was reported as a full frame")
+	}
+	var netErr net.Error
+	if !stderrors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("write error = %v, want timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("write deadline was not enforced promptly: %s", elapsed)
+	}
+}
+
+func TestUnknownUserNotifierSlowClientDoesNotBlockNotify(t *testing.T) {
+	options := defaultUnknownUserNotifierOptions()
+	options.eventQueueSize = 8
+	options.clientQueueSize = 1
+	options.maxClients = 1
+	options.writeTimeout = 5 * time.Second
+
+	notifier := newUnknownUserNotifierState(context.Background(), nil, options)
+	notifier.wg.Add(1)
+	go notifier.broadcast()
+
+	conn := newBlockingNotificationConn()
+	if !notifier.addClient(conn) {
+		t.Fatal("failed to add notification client")
+	}
+	client := notifier.clientSnapshot()[0]
+
+	notifier.Notify(context.Background(), nil, uuid.New())
+	select {
+	case <-conn.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("notification writer did not start")
+	}
+
+	notifier.Notify(context.Background(), nil, uuid.New())
+	waitFor(t, time.Second, func() bool {
+		return len(client.queue) == 1
+	})
+
+	started := time.Now()
+	notifier.Notify(context.Background(), nil, uuid.New())
+	if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+		t.Fatalf("Notify blocked for %s on a slow client", elapsed)
+	}
+
+	waitFor(t, time.Second, func() bool {
+		return notifier.clientCount.Load() == 0
+	})
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- notifier.Close()
+	}()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("notifier close blocked on a slow client")
+	}
+}
+
+func TestUnknownUserNotifierFailedWriteReleasesDedupReservation(t *testing.T) {
+	options := defaultUnknownUserNotifierOptions()
+	options.eventQueueSize = 1
+	options.clientQueueSize = 1
+
+	notifier := newUnknownUserNotifierState(context.Background(), nil, options)
+	notifier.wg.Add(1)
+	go notifier.broadcast()
+
+	conn := newFailingWriteNotificationConn()
+	if !notifier.addClient(conn) {
+		t.Fatal("failed to add notification client")
+	}
+
+	attemptedUUID := mustParseUUID(t, "01234567-89ab-cdef-0123-456789abcdef")
+	notifier.Notify(context.Background(), nil, attemptedUUID)
+	select {
+	case <-conn.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("notification writer did not attempt the frame")
+	}
+	waitFor(t, time.Second, func() bool {
+		return notifier.clientCount.Load() == 0 && notifier.dedup.Len() == 0
+	})
+
+	token, allowed := notifier.dedup.Reserve(attemptedUUID.String(), options.now())
+	if !allowed {
+		t.Fatal("failed UDS write suppressed a retry for the full deduplication TTL")
+	}
+	notifier.dedup.Forget(attemptedUUID.String(), token)
+	if err := notifier.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnknownUserNotifierClientLimit(t *testing.T) {
+	options := defaultUnknownUserNotifierOptions()
+	options.maxClients = 1
+	notifier := newUnknownUserNotifierState(context.Background(), nil, options)
+
+	first := newBlockingNotificationConn()
+	if !notifier.addClient(first) {
+		t.Fatal("first client was rejected")
+	}
+	second := newBlockingNotificationConn()
+	if notifier.addClient(second) {
+		t.Fatal("client beyond configured limit was accepted")
+	}
+	select {
+	case <-second.closed:
+	default:
+		t.Fatal("rejected client was not closed")
+	}
+	if got := notifier.clientCount.Load(); got != 1 {
+		t.Fatalf("active clients = %d, want 1", got)
+	}
+	if err := notifier.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnknownUserNotifierCloseRemovesSocketAndClients(t *testing.T) {
+	socketPath := notificationSocketPath(t)
+	notifier, err := newUnknownUserNotifier(context.Background(), socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	waitFor(t, time.Second, func() bool {
+		return notifier.clientCount.Load() == 1
+	})
+
+	if err := notifier.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := notifier.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+	if _, err := os.Lstat(socketPath); !stderrors.Is(err, os.ErrNotExist) {
+		t.Fatalf("notification socket still exists after close: %v", err)
+	}
+
+	if err := client.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	var buffer [1]byte
+	if _, err := client.Read(buffer[:]); err == nil {
+		t.Fatal("client connection remained open after notifier close")
+	}
+
+	notifier.Notify(context.Background(), nil, uuid.New())
+}
+
+func TestUnknownUserNotifierDoesNotTakeOverLiveSocket(t *testing.T) {
+	socketPath := notificationSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	probeAccepted := acceptNotificationConnection(listener)
+	notifier, err := newUnknownUserNotifier(context.Background(), socketPath)
+	if err == nil {
+		if notifier != nil {
+			_ = notifier.Close()
+		}
+		t.Fatal("live notification socket was taken over")
+	}
+	select {
+	case err := <-probeAccepted:
+		if err != nil {
+			t.Fatalf("accept liveness probe: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("existing listener did not receive liveness probe")
+	}
+	if info, err := os.Lstat(socketPath); err != nil {
+		t.Fatalf("live notification socket was removed: %v", err)
+	} else if info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("live notification path mode = %s, want socket", info.Mode())
+	}
+
+	connectionAccepted := acceptNotificationConnection(listener)
+	client, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial original listener after rejected takeover: %v", err)
+	}
+	_ = client.Close()
+	select {
+	case err := <-connectionAccepted:
+		if err != nil {
+			t.Fatalf("original listener stopped accepting: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("original listener stopped accepting after rejected takeover")
+	}
+}
+
+func TestUnknownUserNotifierReplacesStaleSocket(t *testing.T) {
+	socketPath := notificationSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unixListener, ok := listener.(*net.UnixListener)
+	if !ok {
+		_ = listener.Close()
+		t.Fatalf("listener type = %T, want *net.UnixListener", listener)
+	}
+	unixListener.SetUnlinkOnClose(false)
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(socketPath); err != nil {
+		t.Fatalf("stale socket was not retained for test: %v", err)
+	}
+
+	notifier, err := newUnknownUserNotifier(context.Background(), socketPath)
+	if err != nil {
+		t.Fatalf("replace stale notification socket: %v", err)
+	}
+	if err := notifier.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnknownUserNotifierRefusesToReplaceRegularFile(t *testing.T) {
+	socketPath := notificationSocketPath(t)
+	const contents = "do not replace"
+	if err := os.WriteFile(socketPath, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	notifier, err := newUnknownUserNotifier(context.Background(), socketPath)
+	if err == nil {
+		if notifier != nil {
+			_ = notifier.Close()
+		}
+		t.Fatal("regular file was accepted as notification socket path")
+	}
+	data, readErr := os.ReadFile(socketPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got := string(data); got != contents {
+		t.Fatalf("regular file contents = %q, want %q", got, contents)
+	}
+}
+
+func mustParseUUID(t *testing.T, value string) uuid.UUID {
+	t.Helper()
+	parsed, err := uuid.ParseString(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}
+
+func notificationSocketPath(t *testing.T) string {
+	t.Helper()
+	directory, err := os.MkdirTemp("", "xray-notify-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(directory); err != nil {
+			t.Errorf("remove temporary socket directory: %v", err)
+		}
+	})
+	return filepath.Join(directory, "notify.sock")
+}
+
+func readUnknownUserNotification(t *testing.T, conn net.Conn, timeout time.Duration) *UnknownUserAttempt {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		t.Fatal(err)
+	}
+
+	var lengthBuffer [4]byte
+	if _, err := io.ReadFull(conn, lengthBuffer[:]); err != nil {
+		t.Fatal(err)
+	}
+	length := binary.BigEndian.Uint32(lengthBuffer[:])
+	if length > 64*1024 {
+		t.Fatalf("notification payload is unexpectedly large: %d", length)
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+
+	var attempt UnknownUserAttempt
+	if err := proto.Unmarshal(payload, &attempt); err != nil {
+		t.Fatal(err)
+	}
+	return &attempt
+}
+
+func expectNoNotification(t *testing.T, conn net.Conn, timeout time.Duration) {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		t.Fatal(err)
+	}
+	var buffer [1]byte
+	_, err := conn.Read(buffer[:])
+	var netErr net.Error
+	if !stderrors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("read error = %v, want timeout", err)
+	}
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatal("condition was not met before timeout")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func acceptNotificationConnection(listener net.Listener) <-chan error {
+	accepted := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			err = conn.Close()
+		}
+		accepted <- err
+	}()
+	return accepted
+}
+
+type notificationTestAddr string
+
+func (a notificationTestAddr) Network() string {
+	return "test"
+}
+
+func (a notificationTestAddr) String() string {
+	return string(a)
+}
+
+type shortWriteConn struct {
+	buffer    bytes.Buffer
+	maxWrite  int
+	deadlines []time.Time
+}
+
+func (c *shortWriteConn) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (c *shortWriteConn) Write(buffer []byte) (int, error) {
+	if c.maxWrite == 0 {
+		return 0, nil
+	}
+	if len(buffer) > c.maxWrite {
+		buffer = buffer[:c.maxWrite]
+	}
+	return c.buffer.Write(buffer)
+}
+
+func (*shortWriteConn) Close() error {
+	return nil
+}
+
+func (*shortWriteConn) LocalAddr() net.Addr {
+	return notificationTestAddr("local")
+}
+
+func (*shortWriteConn) RemoteAddr() net.Addr {
+	return notificationTestAddr("remote")
+}
+
+func (*shortWriteConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (*shortWriteConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (c *shortWriteConn) SetWriteDeadline(deadline time.Time) error {
+	c.deadlines = append(c.deadlines, deadline)
+	return nil
+}
+
+type blockingNotificationConn struct {
+	writeStarted chan struct{}
+	closed       chan struct{}
+	writeOnce    sync.Once
+	closeOnce    sync.Once
+}
+
+func newBlockingNotificationConn() *blockingNotificationConn {
+	return &blockingNotificationConn{
+		writeStarted: make(chan struct{}),
+		closed:       make(chan struct{}),
+	}
+}
+
+func (c *blockingNotificationConn) Read([]byte) (int, error) {
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *blockingNotificationConn) Write([]byte) (int, error) {
+	c.writeOnce.Do(func() {
+		close(c.writeStarted)
+	})
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *blockingNotificationConn) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}
+
+func (*blockingNotificationConn) LocalAddr() net.Addr {
+	return notificationTestAddr("local")
+}
+
+func (*blockingNotificationConn) RemoteAddr() net.Addr {
+	return notificationTestAddr("remote")
+}
+
+func (*blockingNotificationConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (*blockingNotificationConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (*blockingNotificationConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+type failingWriteNotificationConn struct {
+	writeStarted chan struct{}
+	closed       chan struct{}
+	writeOnce    sync.Once
+	closeOnce    sync.Once
+}
+
+func newFailingWriteNotificationConn() *failingWriteNotificationConn {
+	return &failingWriteNotificationConn{
+		writeStarted: make(chan struct{}),
+		closed:       make(chan struct{}),
+	}
+}
+
+func (c *failingWriteNotificationConn) Read([]byte) (int, error) {
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *failingWriteNotificationConn) Write([]byte) (int, error) {
+	c.writeOnce.Do(func() {
+		close(c.writeStarted)
+	})
+	return 0, io.ErrClosedPipe
+}
+
+func (c *failingWriteNotificationConn) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}
+
+func (*failingWriteNotificationConn) LocalAddr() net.Addr {
+	return notificationTestAddr("local")
+}
+
+func (*failingWriteNotificationConn) RemoteAddr() net.Addr {
+	return notificationTestAddr("remote")
+}
+
+func (*failingWriteNotificationConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (*failingWriteNotificationConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (*failingWriteNotificationConn) SetWriteDeadline(time.Time) error {
+	return nil
+}

--- a/testing/scenarios/vless_routing_test.go
+++ b/testing/scenarios/vless_routing_test.go
@@ -1,0 +1,770 @@
+package scenarios
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	stdnet "net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/app/commander"
+	"github.com/xtls/xray-core/app/log"
+	"github.com/xtls/xray-core/app/proxyman"
+	proxymancommand "github.com/xtls/xray-core/app/proxyman/command"
+	"github.com/xtls/xray-core/app/router"
+	routercommand "github.com/xtls/xray-core/app/router/command"
+	"github.com/xtls/xray-core/common/geodata"
+	clog "github.com/xtls/xray-core/common/log"
+	xnet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/serial"
+	"github.com/xtls/xray-core/common/uuid"
+	core "github.com/xtls/xray-core/core"
+	"github.com/xtls/xray-core/proxy/blackhole"
+	"github.com/xtls/xray-core/proxy/dokodemo"
+	"github.com/xtls/xray-core/proxy/freedom"
+	"github.com/xtls/xray-core/proxy/vless"
+	vlessencoding "github.com/xtls/xray-core/proxy/vless/encoding"
+	"github.com/xtls/xray-core/proxy/vless/inbound"
+	"github.com/xtls/xray-core/proxy/vless/outbound"
+	"github.com/xtls/xray-core/testing/servers/tcp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	routingTestUser          = "client-42"
+	routingTestRUDomain      = "ru.route.test"
+	routingTestDefaultDomain = "default.route.test"
+	routingTestTargetPort    = xnet.Port(443)
+)
+
+func TestVlessMuxUserDestinationRouting(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix domain sockets are required")
+	}
+
+	firstRouteStarted := make(chan struct{})
+	releaseFirstRoute := make(chan struct{})
+	var startFirstRoute sync.Once
+	var releaseFirstRouteOnce sync.Once
+	releaseFirst := func() {
+		releaseFirstRouteOnce.Do(func() {
+			close(releaseFirstRoute)
+		})
+	}
+
+	ruBackend := tcp.Server{
+		MsgProcessor: func(msg []byte) []byte {
+			startFirstRoute.Do(func() {
+				close(firstRouteStarted)
+			})
+			<-releaseFirstRoute
+			return responseWithMarker('R', msg)
+		},
+	}
+	ruDestination, err := ruBackend.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ruBackend.Close()
+
+	defaultBackend := tcp.Server{
+		MsgProcessor: func(msg []byte) []byte {
+			return responseWithMarker('D', msg)
+		},
+	}
+	defaultDestination, err := defaultBackend.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer defaultBackend.Close()
+
+	canonicalUUID := uuid.New()
+	canonicalUUID[6] = 0
+	canonicalUUID[7] = 0
+	attemptedUUID := canonicalUUID
+	attemptedUUID[6] = 0x12
+	attemptedUUID[7] = 0x34
+	canonicalUserID := protocol.NewID(canonicalUUID)
+	attemptedUserID := protocol.NewID(attemptedUUID)
+	socketDir, err := os.MkdirTemp("/tmp", "xray-routing-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(socketDir)
+	notificationSocket := filepath.Join(socketDir, "notifications.sock")
+	controlSocket := filepath.Join(socketDir, "control.sock")
+
+	serverPort := tcp.PickPort()
+	serverConfig := &core.Config{
+		App: []*serial.TypedMessage{
+			serial.ToTypedMessage(&log.Config{
+				ErrorLogLevel: clog.Severity_Error,
+				ErrorLogType:  log.LogType_Console,
+			}),
+			serial.ToTypedMessage(&router.Config{
+				DomainStrategy: router.Config_AsIs,
+			}),
+			serial.ToTypedMessage(&commander.Config{
+				Tag:    "api",
+				Listen: controlSocket + ",0600",
+				Service: []*serial.TypedMessage{
+					serial.ToTypedMessage(&proxymancommand.Config{}),
+					serial.ToTypedMessage(&routercommand.Config{}),
+				},
+			}),
+		},
+		Inbound: []*core.InboundHandlerConfig{
+			{
+				Tag: "vless-in",
+				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+					PortList: &xnet.PortList{Range: []*xnet.PortRange{xnet.SinglePortRange(serverPort)}},
+					Listen:   xnet.NewIPOrDomain(xnet.LocalHostIP),
+				}),
+				ProxySettings: serial.ToTypedMessage(&inbound.Config{
+					Notifications: notificationSocket,
+				}),
+			},
+		},
+		Outbound: []*core.OutboundHandlerConfig{
+			{
+				Tag:           "deny",
+				ProxySettings: serial.ToTypedMessage(&blackhole.Config{}),
+			},
+			{
+				Tag:           "ru-system",
+				ProxySettings: serial.ToTypedMessage(freedomTo(ruDestination)),
+			},
+			{
+				Tag:           "default-system",
+				ProxySettings: serial.ToTypedMessage(freedomTo(defaultDestination)),
+			},
+		},
+	}
+
+	proxy := newCountingTCPProxy(t, xnet.TCPDestination(xnet.LocalHostIP, serverPort))
+	defer proxy.Close()
+
+	ruClientPort := tcp.PickPort()
+	defaultClientPort := tcp.PickPort()
+	clientConfig := &core.Config{
+		App: []*serial.TypedMessage{
+			serial.ToTypedMessage(&log.Config{
+				ErrorLogLevel: clog.Severity_Error,
+				ErrorLogType:  log.LogType_Console,
+			}),
+		},
+		Inbound: []*core.InboundHandlerConfig{
+			dokodemoInbound("ru-client-in", ruClientPort, routingTestRUDomain),
+			dokodemoInbound("default-client-in", defaultClientPort, routingTestDefaultDomain),
+		},
+		Outbound: []*core.OutboundHandlerConfig{
+			{
+				Tag: "vless-mux",
+				SenderSettings: serial.ToTypedMessage(&proxyman.SenderConfig{
+					MultiplexSettings: &proxyman.MultiplexingConfig{
+						Enabled:     true,
+						Concurrency: 2,
+					},
+				}),
+				ProxySettings: serial.ToTypedMessage(&outbound.Config{
+					Vnext: &protocol.ServerEndpoint{
+						Address: xnet.NewIPOrDomain(xnet.LocalHostIP),
+						Port:    uint32(proxy.Port()),
+						User: &protocol.User{
+							Account: serial.ToTypedMessage(&vless.Account{
+								Id: attemptedUserID.String(),
+							}),
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	servers, err := InitializeServerConfigs(serverConfig, clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer CloseAllServers(servers)
+
+	assertUnixSocketMode(t, notificationSocket, 0o600)
+	assertUnixSocketMode(t, controlSocket, 0o600)
+
+	notificationConn, err := dialUnixSocket(notificationSocket, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer notificationConn.Close()
+
+	controlConn, err := dialGRPCUnixSocket(controlSocket, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer controlConn.Close()
+
+	authResult := make(chan authDaemonResult, 1)
+	go emulateAuthDaemon(
+		notificationConn,
+		proxymancommand.NewHandlerServiceClient(controlConn),
+		routercommand.NewRoutingServiceClient(controlConn),
+		attemptedUserID.String(),
+		canonicalUserID.String(),
+		authResult,
+	)
+
+	var provisioned authDaemonResult
+	authDeadline := time.NewTimer(10 * time.Second)
+	defer authDeadline.Stop()
+	for {
+		if err := attemptUnknownVLESS(proxy.Port(), attemptedUserID); err != nil {
+			t.Fatal(err)
+		}
+
+		select {
+		case provisioned = <-authResult:
+			if provisioned.err != nil {
+				t.Fatal(provisioned.err)
+			}
+			goto userProvisioned
+		case <-authDeadline.C:
+			t.Fatal("auth daemon did not receive the unknown-user notification")
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+
+userProvisioned:
+	if provisioned.attempt.GetAttemptedUuid() != attemptedUserID.String() {
+		t.Fatalf(
+			"notified UUID = %q, want %q",
+			provisioned.attempt.GetAttemptedUuid(),
+			attemptedUserID.String(),
+		)
+	}
+	if provisioned.attempt.GetRemoteIp() == "" ||
+		provisioned.attempt.GetRemotePort() == 0 ||
+		provisioned.attempt.GetTimestamp() == 0 {
+		t.Fatalf("incomplete unknown-user notification: %+v", provisioned.attempt)
+	}
+
+	handlerClient := proxymancommand.NewHandlerServiceClient(controlConn)
+	usersCtx, cancelUsers := context.WithTimeout(context.Background(), 5*time.Second)
+	users, err := handlerClient.GetInboundUsers(usersCtx, &proxymancommand.GetInboundUserRequest{
+		Tag:   "vless-in",
+		Email: routingTestUser,
+	})
+	cancelUsers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users.GetUsers()) != 1 || users.GetUsers()[0].GetEmail() != routingTestUser {
+		t.Fatalf("dynamic VLESS users = %+v, want %q", users.GetUsers(), routingTestUser)
+	}
+
+	failedAuthConnections := proxy.AcceptCount()
+	if failedAuthConnections == 0 {
+		t.Fatal("unknown UUID did not open a physical VLESS connection")
+	}
+
+	defer releaseFirst()
+	firstRouteResult := make(chan error, 1)
+	go func() {
+		firstRouteResult <- exchangeRoute(ruClientPort, []byte("ru-route"), 'R')
+	}()
+
+	select {
+	case <-firstRouteStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("first logical mux stream did not reach the ru backend")
+	}
+
+	if err := exchangeRoute(defaultClientPort, []byte("default-route"), 'D'); err != nil {
+		t.Fatal(err)
+	}
+
+	releaseFirst()
+	select {
+	case err := <-firstRouteResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("first logical mux stream did not finish")
+	}
+
+	if got, want := proxy.AcceptCount(), failedAuthConnections+1; got != want {
+		t.Fatalf(
+			"post-auth physical VLESS connections through mux = %d, want one new connection after %d failed auth connections",
+			got-failedAuthConnections,
+			failedAuthConnections,
+		)
+	}
+}
+
+func routingRule(user, domain, outboundTag, ruleTag string) *router.RoutingRule {
+	rule := &router.RoutingRule{
+		TargetTag: &router.RoutingRule_Tag{
+			Tag: outboundTag,
+		},
+		RuleTag:    ruleTag,
+		InboundTag: []string{"vless-in"},
+		UserEmail:  []string{user},
+	}
+	if domain != "" {
+		rule.Domain = []*geodata.DomainRule{
+			{
+				Value: &geodata.DomainRule_Custom{
+					Custom: &geodata.Domain{
+						Type:  geodata.Domain_Full,
+						Value: domain,
+					},
+				},
+			},
+		}
+	}
+	return rule
+}
+
+type authDaemonResult struct {
+	attempt *inbound.UnknownUserAttempt
+	err     error
+}
+
+func emulateAuthDaemon(
+	notificationConn stdnet.Conn,
+	handlerClient proxymancommand.HandlerServiceClient,
+	routingClient routercommand.RoutingServiceClient,
+	attemptedUUID string,
+	canonicalUUID string,
+	result chan<- authDaemonResult,
+) {
+	attempt, err := readUnknownUserAttempt(notificationConn)
+	if err != nil {
+		result <- authDaemonResult{err: err}
+		return
+	}
+	if attempt.GetAttemptedUuid() != attemptedUUID {
+		result <- authDaemonResult{
+			attempt: attempt,
+			err: fmt.Errorf(
+				"auth backend lookup UUID = %q, want %q",
+				attempt.GetAttemptedUuid(),
+				attemptedUUID,
+			),
+		}
+		return
+	}
+	attemptedID, err := uuid.ParseString(attempt.GetAttemptedUuid())
+	if err != nil {
+		result <- authDaemonResult{attempt: attempt, err: fmt.Errorf("parsing attempted UUID: %w", err)}
+		return
+	}
+	canonicalID, err := uuid.ParseString(canonicalUUID)
+	if err != nil {
+		result <- authDaemonResult{attempt: attempt, err: fmt.Errorf("parsing canonical UUID: %w", err)}
+		return
+	}
+	if vless.ProcessUUID(attemptedID) != vless.ProcessUUID(canonicalID) {
+		result <- authDaemonResult{
+			attempt: attempt,
+			err:     fmt.Errorf("attempted UUID does not map to the canonical credential"),
+		}
+		return
+	}
+
+	getCtx, cancelGet := context.WithTimeout(context.Background(), 5*time.Second)
+	current, err := routingClient.GetRuleSet(getCtx, &routercommand.GetRuleSetRequest{})
+	cancelGet()
+	if err != nil {
+		result <- authDaemonResult{attempt: attempt, err: fmt.Errorf("getting route state: %w", err)}
+		return
+	}
+
+	routeConfig := &router.Config{
+		DomainStrategy: router.Config_AsIs,
+		Rule: []*router.RoutingRule{
+			routingRule(
+				routingTestUser,
+				routingTestRUDomain,
+				"ru-system",
+				"client-42-ru",
+			),
+			routingRule(
+				routingTestUser,
+				"",
+				"default-system",
+				"client-42-default",
+			),
+		},
+	}
+	replaceCtx, cancelReplace := context.WithTimeout(context.Background(), 5*time.Second)
+	replaced, err := routingClient.ReplaceRuleSet(
+		replaceCtx,
+		&routercommand.ReplaceRuleSetRequest{
+			ExpectedVersion: current.GetVersion(),
+			Config:          serial.ToTypedMessage(routeConfig),
+		},
+	)
+	cancelReplace()
+	if err != nil {
+		result <- authDaemonResult{attempt: attempt, err: fmt.Errorf("replacing route state: %w", err)}
+		return
+	}
+	if replaced.GetVersion().GetInstanceId() != current.GetVersion().GetInstanceId() ||
+		replaced.GetVersion().GetGeneration() != current.GetVersion().GetGeneration()+1 {
+		result <- authDaemonResult{
+			attempt: attempt,
+			err: fmt.Errorf(
+				"route version changed from %+v to %+v",
+				current.GetVersion(),
+				replaced.GetVersion(),
+			),
+		}
+		return
+	}
+
+	addCtx, cancelAdd := context.WithTimeout(context.Background(), 5*time.Second)
+	_, err = handlerClient.AlterInbound(addCtx, &proxymancommand.AlterInboundRequest{
+		Tag: "vless-in",
+		Operation: serial.ToTypedMessage(&proxymancommand.AddUserOperation{
+			User: &protocol.User{
+				Email: routingTestUser,
+				Account: serial.ToTypedMessage(&vless.Account{
+					Id: canonicalUUID,
+				}),
+			},
+		}),
+	})
+	cancelAdd()
+	if err != nil {
+		result <- authDaemonResult{attempt: attempt, err: fmt.Errorf("adding VLESS user: %w", err)}
+		return
+	}
+
+	result <- authDaemonResult{attempt: attempt}
+}
+
+func readUnknownUserAttempt(conn stdnet.Conn) (*inbound.UnknownUserAttempt, error) {
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return nil, fmt.Errorf("setting notification deadline: %w", err)
+	}
+
+	var sizeBytes [4]byte
+	if _, err := io.ReadFull(conn, sizeBytes[:]); err != nil {
+		return nil, fmt.Errorf("reading notification size: %w", err)
+	}
+	size := binary.BigEndian.Uint32(sizeBytes[:])
+	const maxNotificationSize = 64 * 1024
+	if size == 0 || size > maxNotificationSize {
+		return nil, fmt.Errorf("invalid notification size %d", size)
+	}
+
+	body := make([]byte, size)
+	if _, err := io.ReadFull(conn, body); err != nil {
+		return nil, fmt.Errorf("reading notification body: %w", err)
+	}
+	attempt := new(inbound.UnknownUserAttempt)
+	if err := proto.Unmarshal(body, attempt); err != nil {
+		return nil, fmt.Errorf("decoding unknown-user notification: %w", err)
+	}
+	return attempt, nil
+}
+
+func dialUnixSocket(path string, timeout time.Duration) (stdnet.Conn, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		connection, err := stdnet.DialTimeout("unix", path, 250*time.Millisecond)
+		if err == nil {
+			return connection, nil
+		}
+		lastErr = err
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("dialing Unix socket %q: %w", path, lastErr)
+}
+
+func dialGRPCUnixSocket(path string, timeout time.Duration) (*grpc.ClientConn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return grpc.DialContext(
+		ctx,
+		"passthrough:///xray-control",
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (stdnet.Conn, error) {
+			var dialer stdnet.Dialer
+			return dialer.DialContext(ctx, "unix", path)
+		}),
+	)
+}
+
+func assertUnixSocketMode(t *testing.T, path string, expected os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat Unix socket %q: %v", path, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("%q is not a Unix socket: %v", path, info.Mode())
+	}
+	if got := info.Mode().Perm(); got != expected {
+		t.Fatalf("Unix socket %q mode = %04o, want %04o", path, got, expected)
+	}
+}
+
+func attemptUnknownVLESS(port xnet.Port, id *protocol.ID) error {
+	address := stdnet.JoinHostPort("127.0.0.1", port.String())
+	connection, err := stdnet.DialTimeout("tcp", address, 2*time.Second)
+	if err != nil {
+		return fmt.Errorf("dialing VLESS auth attempt: %w", err)
+	}
+	defer connection.Close()
+	if err := connection.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		return fmt.Errorf("setting VLESS auth deadline: %w", err)
+	}
+
+	account, err := (&vless.Account{Id: id.String()}).AsAccount()
+	if err != nil {
+		return fmt.Errorf("building VLESS auth account: %w", err)
+	}
+	request := &protocol.RequestHeader{
+		Version: vlessencoding.Version,
+		User: &protocol.MemoryUser{
+			Account: account,
+		},
+		Command: protocol.RequestCommandTCP,
+		Address: xnet.DomainAddress(routingTestRUDomain),
+		Port:    routingTestTargetPort,
+	}
+	if err := vlessencoding.EncodeRequestHeader(
+		connection,
+		request,
+		&vlessencoding.Addons{},
+	); err != nil {
+		return fmt.Errorf("writing VLESS auth attempt: %w", err)
+	}
+
+	var response [1]byte
+	if _, err := connection.Read(response[:]); err == nil {
+		return fmt.Errorf("unknown VLESS user received a response")
+	}
+	return nil
+}
+
+func freedomTo(destination xnet.Destination) *freedom.Config {
+	return &freedom.Config{
+		DestinationOverride: &freedom.DestinationOverride{
+			Server: &protocol.ServerEndpoint{
+				Address: xnet.NewIPOrDomain(destination.Address),
+				Port:    uint32(destination.Port),
+			},
+		},
+		FinalRules: []*freedom.FinalRuleConfig{
+			{Action: freedom.RuleAction_Allow},
+		},
+	}
+}
+
+func dokodemoInbound(tag string, port xnet.Port, domain string) *core.InboundHandlerConfig {
+	return &core.InboundHandlerConfig{
+		Tag: tag,
+		ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+			PortList: &xnet.PortList{Range: []*xnet.PortRange{xnet.SinglePortRange(port)}},
+			Listen:   xnet.NewIPOrDomain(xnet.LocalHostIP),
+		}),
+		ProxySettings: serial.ToTypedMessage(&dokodemo.Config{
+			RewriteAddress:  xnet.NewIPOrDomain(xnet.DomainAddress(domain)),
+			RewritePort:     uint32(routingTestTargetPort),
+			AllowedNetworks: []xnet.Network{xnet.Network_TCP},
+		}),
+	}
+}
+
+func responseWithMarker(marker byte, msg []byte) []byte {
+	response := append([]byte(nil), msg...)
+	if len(response) > 0 {
+		response[0] = marker
+	}
+	return response
+}
+
+func exchangeRoute(port xnet.Port, payload []byte, marker byte) error {
+	return exchangeRouteWithTimeout(port, payload, marker, 10*time.Second)
+}
+
+func exchangeRouteWithTimeout(
+	port xnet.Port,
+	payload []byte,
+	marker byte,
+	timeout time.Duration,
+) error {
+	address := stdnet.JoinHostPort("127.0.0.1", strconv.Itoa(int(port)))
+	connection, err := stdnet.DialTimeout("tcp", address, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("dialing route %q: %w", address, err)
+	}
+	defer connection.Close()
+
+	if err := connection.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return fmt.Errorf("setting route deadline: %w", err)
+	}
+	if _, err := connection.Write(payload); err != nil {
+		return fmt.Errorf("writing route payload: %w", err)
+	}
+
+	response := make([]byte, len(payload))
+	if _, err := io.ReadFull(connection, response); err != nil {
+		return fmt.Errorf("reading route response: %w", err)
+	}
+	expected := responseWithMarker(marker, payload)
+	if !bytes.Equal(response, expected) {
+		return fmt.Errorf("route response = %q, want %q", response, expected)
+	}
+	return nil
+}
+
+type countingTCPProxy struct {
+	listener    stdnet.Listener
+	target      string
+	acceptCount atomic.Int32
+
+	mu          sync.Mutex
+	isClosed    bool
+	connections map[stdnet.Conn]struct{}
+	acceptDone  chan struct{}
+	handlers    sync.WaitGroup
+	closeOnce   sync.Once
+}
+
+func newCountingTCPProxy(t *testing.T, destination xnet.Destination) *countingTCPProxy {
+	t.Helper()
+
+	listener, err := stdnet.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("starting counting TCP proxy: %v", err)
+	}
+	proxy := &countingTCPProxy{
+		listener: listener,
+		target: stdnet.JoinHostPort(
+			destination.Address.String(),
+			strconv.Itoa(int(destination.Port)),
+		),
+		connections: make(map[stdnet.Conn]struct{}),
+		acceptDone:  make(chan struct{}),
+	}
+	go proxy.accept()
+	return proxy
+}
+
+func (p *countingTCPProxy) Port() xnet.Port {
+	return xnet.Port(p.listener.Addr().(*stdnet.TCPAddr).Port)
+}
+
+func (p *countingTCPProxy) AcceptCount() int32 {
+	return p.acceptCount.Load()
+}
+
+func (p *countingTCPProxy) Close() {
+	p.closeOnce.Do(func() {
+		p.mu.Lock()
+		p.isClosed = true
+		connections := make([]stdnet.Conn, 0, len(p.connections))
+		for connection := range p.connections {
+			connections = append(connections, connection)
+		}
+		p.mu.Unlock()
+
+		_ = p.listener.Close()
+		for _, connection := range connections {
+			_ = connection.Close()
+		}
+
+		<-p.acceptDone
+		p.handlers.Wait()
+	})
+}
+
+func (p *countingTCPProxy) accept() {
+	defer close(p.acceptDone)
+
+	for {
+		connection, err := p.listener.Accept()
+		if err != nil {
+			return
+		}
+		if !p.register(connection) {
+			continue
+		}
+
+		p.acceptCount.Add(1)
+		p.handlers.Add(1)
+		go p.forward(connection)
+	}
+}
+
+func (p *countingTCPProxy) forward(downstream stdnet.Conn) {
+	defer p.handlers.Done()
+	defer p.unregister(downstream)
+
+	upstream, err := stdnet.DialTimeout("tcp", p.target, 5*time.Second)
+	if err != nil {
+		_ = downstream.Close()
+		return
+	}
+	if !p.register(upstream) {
+		_ = downstream.Close()
+		return
+	}
+	defer p.unregister(upstream)
+
+	var copies sync.WaitGroup
+	copies.Add(2)
+	go func() {
+		defer copies.Done()
+		_, _ = io.Copy(upstream, downstream)
+		closeWrite(upstream)
+	}()
+	go func() {
+		defer copies.Done()
+		_, _ = io.Copy(downstream, upstream)
+		closeWrite(downstream)
+	}()
+	copies.Wait()
+}
+
+func (p *countingTCPProxy) register(connection stdnet.Conn) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.isClosed {
+		_ = connection.Close()
+		return false
+	}
+	p.connections[connection] = struct{}{}
+	return true
+}
+
+func (p *countingTCPProxy) unregister(connection stdnet.Conn) {
+	p.mu.Lock()
+	delete(p.connections, connection)
+	p.mu.Unlock()
+	_ = connection.Close()
+}
+
+func closeWrite(connection stdnet.Conn) {
+	if tcpConnection, ok := connection.(*stdnet.TCPConn); ok {
+		_ = tcpConnection.CloseWrite()
+	}
+}


### PR DESCRIPTION
## What

- Report unknown VLESS UUIDs to a local auth service over a Unix socket.
- Let the service add authenticated users through the existing Handler API.
- Replace the complete ordered routing ruleset atomically.
- Route connections by authenticated user and destination.

This lets the backend add users and update routing without restarting Xray or exposing an intermediate rule order.

## Scope

This PR does **not** include per-user `fwmark`, strict socket binding, transport changes, or Docker rehearsal files. The Linux `VLESS -> Freedom` fwmark support is split into a separate change.

## Tests

Unit and scenario tests cover unknown-user notifications, atomic rule replacement, API round trips, and authenticated VLESS user routing.
