### PR TITLE
Add best-effort per-user VLESS fwmarks

### DIFF
--- a/app/proxyman/command/user_fwmark_test.go
+++ b/app/proxyman/command/user_fwmark_test.go
@@ -1,0 +1,24 @@
+package command
+
+import (
+	"math"
+	"testing"
+
+	"github.com/xtls/xray-core/common/protocol"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestAddUserOperationFwmarkRoundTrip(t *testing.T) {
+	original := &AddUserOperation{User: &protocol.User{Fwmark: math.MaxUint32}}
+	wire, err := proto.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded := new(AddUserOperation)
+	if err := proto.Unmarshal(wire, decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.GetUser().GetFwmark() != math.MaxUint32 {
+		t.Fatalf("fwmark = %d, want %d", decoded.GetUser().GetFwmark(), uint32(math.MaxUint32))
+	}
+}

--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -6,6 +6,7 @@ import (
 	goerrors "errors"
 	"io"
 	"math/big"
+	"runtime"
 
 	"github.com/xtls/xray-core/common/dice"
 
@@ -181,6 +182,11 @@ func (h *Handler) Tag() string {
 func (h *Handler) Dispatch(ctx context.Context, link *transport.Link) {
 	outbounds := session.OutboundsFromContext(ctx)
 	ob := outbounds[len(outbounds)-1]
+	var outboundSocketMark uint32
+	if preparer, ok := h.proxy.(proxy.OutboundContextPreparer); ok {
+		ctx = preparer.PrepareOutboundContext(ctx)
+		outboundSocketMark = session.OutboundSocketMarkFromContext(ctx)
+	}
 	content := session.ContentFromContext(ctx)
 	if h.senderSettings != nil && h.senderSettings.TargetStrategy.HasStrategy() && ob.Target.Address.Family().IsDomain() && (content == nil || !content.SkipDNSResolve) {
 		strategy := h.senderSettings.TargetStrategy
@@ -208,7 +214,7 @@ func (h *Handler) Dispatch(ctx context.Context, link *transport.Link) {
 		link.Reader = &buf.EndpointOverrideReader{Reader: link.Reader, Dest: ob.Target.Address, OriginalDest: ob.OriginalTarget.Address}
 		link.Writer = &buf.EndpointOverrideWriter{Writer: link.Writer, Dest: ob.Target.Address, OriginalDest: ob.OriginalTarget.Address}
 	}
-	if h.mux != nil {
+	if h.mux != nil && shouldDispatchViaMux(outboundSocketMark) {
 		test := func(err error) {
 			if err != nil {
 				err := errors.New("failed to process mux outbound traffic").Base(err)
@@ -309,7 +315,16 @@ func (h *Handler) Dial(ctx context.Context, dest net.Destination) (stat.Connecti
 		}
 	}
 
-	conn, err := internet.Dial(ctx, dest, h.streamSettings)
+	streamSettings := h.streamSettings
+	if mark := session.OutboundSocketMarkFromContext(ctx); mark != 0 {
+		var applied bool
+		streamSettings, applied = streamSettingsWithOutboundSocketMark(streamSettings, mark, runtime.GOOS, dest.Network)
+		if !applied {
+			errors.LogInfo(ctx, "per-user fwmark is supported only by a direct Freedom outbound on Linux; continuing without it")
+		}
+	}
+
+	conn, err := internet.Dial(ctx, dest, streamSettings)
 	conn = h.getStatCouterConnection(conn)
 	outbounds := session.OutboundsFromContext(ctx)
 	if outbounds != nil {

--- a/app/proxyman/outbound/socket_mark.go
+++ b/app/proxyman/outbound/socket_mark.go
@@ -1,0 +1,34 @@
+package outbound
+
+import (
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/transport/internet"
+	"google.golang.org/protobuf/proto"
+)
+
+func streamSettingsWithOutboundSocketMark(settings *internet.MemoryStreamConfig, mark uint32, goos string, network net.Network) (*internet.MemoryStreamConfig, bool) {
+	if mark == 0 || goos != "linux" {
+		return settings, false
+	}
+	if network == net.Network_TCP && settings != nil && settings.ProtocolName != "" && settings.ProtocolName != "tcp" {
+		return settings, false
+	}
+	if settings == nil {
+		settings = &internet.MemoryStreamConfig{ProtocolName: "tcp"}
+	}
+
+	cloned := *settings
+	if settings.SocketSettings == nil {
+		cloned.SocketSettings = new(internet.SocketConfig)
+	} else {
+		cloned.SocketSettings = proto.Clone(settings.SocketSettings).(*internet.SocketConfig)
+	}
+	// SocketConfig.Mark is int32 for compatibility, while SO_MARK consumes the
+	// same low 32 bits. Preserve the full per-user uint32 value explicitly.
+	cloned.SocketSettings.Mark = int32(mark)
+	return &cloned, true
+}
+
+func shouldDispatchViaMux(mark uint32) bool {
+	return mark == 0
+}

--- a/app/proxyman/outbound/socket_mark_test.go
+++ b/app/proxyman/outbound/socket_mark_test.go
@@ -1,0 +1,109 @@
+package outbound
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/transport/internet"
+)
+
+func TestStreamSettingsWithOutboundSocketMarkIsCallScoped(t *testing.T) {
+	baseSocket := &internet.SocketConfig{Mark: 7, TcpKeepAliveInterval: 11}
+	base := &internet.MemoryStreamConfig{ProtocolName: "tcp", SocketSettings: baseSocket}
+
+	got, applied := streamSettingsWithOutboundSocketMark(base, math.MaxUint32, "linux", net.Network_TCP)
+	if !applied {
+		t.Fatal("Linux direct mark was not applied")
+	}
+	if got == base || got.SocketSettings == baseSocket {
+		t.Fatal("shared stream settings were reused")
+	}
+	if uint32(got.SocketSettings.Mark) != math.MaxUint32 {
+		t.Fatalf("socket mark bits = %d, want %d", uint32(got.SocketSettings.Mark), uint32(math.MaxUint32))
+	}
+	if baseSocket.Mark != 7 {
+		t.Fatalf("shared socket settings were mutated: %+v", baseSocket)
+	}
+}
+
+func TestStreamSettingsWithOutboundSocketMarkCreatesDefaults(t *testing.T) {
+	got, applied := streamSettingsWithOutboundSocketMark(nil, 1_000_000_000, "linux", net.Network_TCP)
+	if !applied || got == nil || got.SocketSettings == nil {
+		t.Fatalf("settings = %+v, applied = %v", got, applied)
+	}
+	if uint32(got.SocketSettings.Mark) != 1_000_000_000 {
+		t.Fatalf("socket mark = %d, want %d", uint32(got.SocketSettings.Mark), uint32(1_000_000_000))
+	}
+}
+
+func TestStreamSettingsWithOutboundSocketMarkIsBestEffortOutsideContract(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *internet.MemoryStreamConfig
+		goos     string
+		network  net.Network
+	}{
+		{name: "disabled", settings: &internet.MemoryStreamConfig{ProtocolName: "tcp"}, goos: "linux", network: net.Network_TCP},
+		{name: "non linux", settings: &internet.MemoryStreamConfig{ProtocolName: "tcp"}, goos: "darwin", network: net.Network_TCP},
+		{name: "pooled transport", settings: &internet.MemoryStreamConfig{ProtocolName: "splithttp"}, goos: "linux", network: net.Network_TCP},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mark := uint32(1_000_000_000)
+			if test.name == "disabled" {
+				mark = 0
+			}
+			got, applied := streamSettingsWithOutboundSocketMark(test.settings, mark, test.goos, test.network)
+			if applied {
+				t.Fatal("mark unexpectedly applied")
+			}
+			if got != test.settings {
+				t.Fatal("unsupported settings were cloned or changed")
+			}
+		})
+	}
+}
+
+func TestStreamSettingsWithOutboundSocketMarkConcurrentClones(t *testing.T) {
+	baseSocket := &internet.SocketConfig{Mark: 7}
+	base := &internet.MemoryStreamConfig{ProtocolName: "tcp", SocketSettings: baseSocket}
+	marks := []uint32{1_000_000_000, math.MaxUint32}
+
+	var wg sync.WaitGroup
+	for _, mark := range marks {
+		wg.Add(1)
+		go func(mark uint32) {
+			defer wg.Done()
+			got, applied := streamSettingsWithOutboundSocketMark(base, mark, "linux", net.Network_TCP)
+			if !applied || uint32(got.SocketSettings.Mark) != mark {
+				t.Errorf("mark = %d, applied = %v; want %d, true", uint32(got.SocketSettings.Mark), applied, mark)
+			}
+		}(mark)
+	}
+	wg.Wait()
+	if baseSocket.Mark != 7 {
+		t.Fatalf("shared socket settings were mutated: %+v", baseSocket)
+	}
+}
+
+func TestStreamSettingsWithOutboundSocketMarkAllowsDirectUDP(t *testing.T) {
+	base := &internet.MemoryStreamConfig{ProtocolName: "splithttp"}
+	got, applied := streamSettingsWithOutboundSocketMark(base, 1_000_000_000, "linux", net.Network_UDP)
+	if !applied || uint32(got.SocketSettings.Mark) != 1_000_000_000 {
+		t.Fatalf("UDP mark = %d, applied = %v", uint32(got.SocketSettings.Mark), applied)
+	}
+	if got == base {
+		t.Fatal("shared UDP settings were reused")
+	}
+}
+
+func TestPerUserMarkBypassesSharedOutboundMux(t *testing.T) {
+	if shouldDispatchViaMux(1_000_000_000) {
+		t.Fatal("marked flow may not use a shared outbound mux")
+	}
+	if !shouldDispatchViaMux(0) {
+		t.Fatal("unmarked flow should preserve configured mux behavior")
+	}
+}

--- a/common/protocol/user.go
+++ b/common/protocol/user.go
@@ -32,6 +32,7 @@ func (u *User) ToMemoryUser() (*MemoryUser, error) {
 		Account: account,
 		Email:   u.Email,
 		Level:   u.Level,
+		Fwmark:  u.Fwmark,
 	}, nil
 }
 
@@ -43,6 +44,7 @@ func ToProtoUser(mu *MemoryUser) *User {
 		Account: serial.ToTypedMessage(mu.Account.ToProto()),
 		Email:   mu.Email,
 		Level:   mu.Level,
+		Fwmark:  mu.Fwmark,
 	}
 }
 
@@ -52,4 +54,5 @@ type MemoryUser struct {
 	Account Account
 	Email   string
 	Level   uint32
+	Fwmark  uint32
 }

--- a/common/protocol/user.pb.go
+++ b/common/protocol/user.pb.go
@@ -30,6 +30,7 @@ type User struct {
 	// Protocol specific account information. Must be the account proto in one of
 	// the proxies.
 	Account       *serial.TypedMessage `protobuf:"bytes,3,opt,name=account,proto3" json:"account,omitempty"`
+	Fwmark        uint32               `protobuf:"varint,4,opt,name=fwmark,proto3" json:"fwmark,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -85,15 +86,23 @@ func (x *User) GetAccount() *serial.TypedMessage {
 	return nil
 }
 
+func (x *User) GetFwmark() uint32 {
+	if x != nil {
+		return x.Fwmark
+	}
+	return 0
+}
+
 var File_common_protocol_user_proto protoreflect.FileDescriptor
 
 const file_common_protocol_user_proto_rawDesc = "" +
 	"\n" +
-	"\x1acommon/protocol/user.proto\x12\x14xray.common.protocol\x1a!common/serial/typed_message.proto\"n\n" +
+	"\x1acommon/protocol/user.proto\x12\x14xray.common.protocol\x1a!common/serial/typed_message.proto\"\x86\x01\n" +
 	"\x04User\x12\x14\n" +
 	"\x05level\x18\x01 \x01(\rR\x05level\x12\x14\n" +
 	"\x05email\x18\x02 \x01(\tR\x05email\x12:\n" +
-	"\aaccount\x18\x03 \x01(\v2 .xray.common.serial.TypedMessageR\aaccountB^\n" +
+	"\aaccount\x18\x03 \x01(\v2 .xray.common.serial.TypedMessageR\aaccount\x12\x16\n" +
+	"\x06fwmark\x18\x04 \x01(\rR\x06fwmarkB^\n" +
 	"\x18com.xray.common.protocolP\x01Z)github.com/xtls/xray-core/common/protocol\xaa\x02\x14Xray.Common.Protocolb\x06proto3"
 
 var (

--- a/common/protocol/user.proto
+++ b/common/protocol/user.proto
@@ -16,4 +16,6 @@ message User {
   // Protocol specific account information. Must be the account proto in one of
   // the proxies.
   xray.common.serial.TypedMessage account = 3;
+
+  uint32 fwmark = 4;
 }

--- a/common/session/context.go
+++ b/common/session/context.go
@@ -27,7 +27,8 @@ const (
 	mitmAlpn11Key             ctx.SessionKey = 11 // used by TLS dialer
 	mitmServerNameKey         ctx.SessionKey = 12 // used by TLS dialer
 
-	streamSettingsKey ctx.SessionKey = 13
+	streamSettingsKey     ctx.SessionKey = 13
+	outboundSocketMarkKey ctx.SessionKey = 14
 )
 
 func ContextWithInbound(ctx context.Context, inbound *Inbound) context.Context {
@@ -201,4 +202,15 @@ func ContextWithStreamSettings(ctx context.Context, streamSettings any) context.
 
 func StreamSettingsFromContext(ctx context.Context) any {
 	return ctx.Value(streamSettingsKey)
+}
+
+func ContextWithOutboundSocketMark(ctx context.Context, mark uint32) context.Context {
+	return context.WithValue(ctx, outboundSocketMarkKey, mark)
+}
+
+func OutboundSocketMarkFromContext(ctx context.Context) uint32 {
+	if mark, ok := ctx.Value(outboundSocketMarkKey).(uint32); ok {
+		return mark
+	}
+	return 0
 }

--- a/common/session/user_fwmark_test.go
+++ b/common/session/user_fwmark_test.go
@@ -1,0 +1,17 @@
+package session
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+func TestOutboundSocketMarkContext(t *testing.T) {
+	ctx := ContextWithOutboundSocketMark(context.Background(), math.MaxUint32)
+	if got := OutboundSocketMarkFromContext(ctx); got != math.MaxUint32 {
+		t.Fatalf("mark = %d, want %d", got, uint32(math.MaxUint32))
+	}
+	if got := OutboundSocketMarkFromContext(context.Background()); got != 0 {
+		t.Fatalf("unset mark = %d, want 0", got)
+	}
+}

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -59,6 +59,9 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 		if err := json.Unmarshal(rawUser, user); err != nil {
 			return errors.New(`VLESS users: invalid user`).Base(err)
 		}
+		if err := vless.ValidateUserFwmark(user.Fwmark); err != nil {
+			return errors.New("VLESS users: invalid fwmark").Base(err)
+		}
 		account := new(vless.Account)
 		if err := json.Unmarshal(rawUser, account); err != nil {
 			return errors.New(`VLESS users: invalid user`).Base(err)

--- a/infra/conf/vless_test.go
+++ b/infra/conf/vless_test.go
@@ -1,6 +1,9 @@
 package conf_test
 
 import (
+	"encoding/json"
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/xtls/xray-core/common/net"
@@ -11,6 +14,45 @@ import (
 	"github.com/xtls/xray-core/proxy/vless/inbound"
 	"github.com/xtls/xray-core/proxy/vless/outbound"
 )
+
+func TestVLessInboundFwmark(t *testing.T) {
+	tests := []struct {
+		name         string
+		fwmarkField  string
+		want         uint32
+		wantBuildErr bool
+	}{
+		{name: "omitted"},
+		{name: "disabled", fwmarkField: `,"fwmark":0`},
+		{name: "negative", fwmarkField: `,"fwmark":-1`, wantBuildErr: true},
+		{name: "below range", fwmarkField: `,"fwmark":999999999`, wantBuildErr: true},
+		{name: "minimum", fwmarkField: `,"fwmark":1000000000`, want: 1_000_000_000},
+		{name: "maximum", fwmarkField: `,"fwmark":4294967295`, want: math.MaxUint32},
+		{name: "above uint32", fwmarkField: `,"fwmark":4294967296`, wantBuildErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := fmt.Sprintf(`{"clients":[{"id":"27848739-7e62-4138-9fd3-098a63964b6b"%s}],"decryption":"none"}`, test.fwmarkField)
+			config := new(VLessInboundConfig)
+			if err := json.Unmarshal([]byte(input), config); err != nil {
+				t.Fatal(err)
+			}
+			built, err := config.Build()
+			if test.wantBuildErr {
+				if err == nil {
+					t.Fatal("Build() unexpectedly succeeded")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := built.(*inbound.Config).Users[0].Fwmark; got != test.want {
+				t.Fatalf("fwmark = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
 
 func TestVLessOutbound(t *testing.T) {
 	creator := func() Buildable {

--- a/proxy/freedom/freedom.go
+++ b/proxy/freedom/freedom.go
@@ -267,6 +267,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 	ob.Name = "freedom"
 	ob.CanSpliceCopy = 1
 	inbound := session.InboundFromContext(ctx)
+	ctx = h.PrepareOutboundContext(ctx)
 	defaultRule := getDefaultFinalRule(inbound)
 
 	destination := ob.Target

--- a/proxy/freedom/user_fwmark.go
+++ b/proxy/freedom/user_fwmark.go
@@ -1,0 +1,21 @@
+package freedom
+
+import (
+	"context"
+
+	"github.com/xtls/xray-core/common/session"
+)
+
+func contextWithVLESSUserFwmark(ctx context.Context) context.Context {
+	inbound := session.InboundFromContext(ctx)
+	if inbound == nil || inbound.Name != "vless" || inbound.User == nil || inbound.User.Fwmark == 0 {
+		return ctx
+	}
+	return session.ContextWithOutboundSocketMark(ctx, inbound.User.Fwmark)
+}
+
+// PrepareOutboundContext attaches the authenticated VLESS user's mark before
+// the outbound handler decides whether a shared mux can be used.
+func (*Handler) PrepareOutboundContext(ctx context.Context) context.Context {
+	return contextWithVLESSUserFwmark(ctx)
+}

--- a/proxy/freedom/user_fwmark_test.go
+++ b/proxy/freedom/user_fwmark_test.go
@@ -1,0 +1,37 @@
+package freedom
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/session"
+)
+
+func TestContextWithVLESSUserFwmark(t *testing.T) {
+	tests := []struct {
+		name     string
+		inbound  *session.Inbound
+		wantMark uint32
+	}{
+		{name: "missing inbound"},
+		{name: "missing user", inbound: &session.Inbound{Name: "vless"}},
+		{name: "disabled", inbound: &session.Inbound{Name: "vless", User: &protocol.MemoryUser{Fwmark: 0}}},
+		{name: "other protocol", inbound: &session.Inbound{Name: "vmess", User: &protocol.MemoryUser{Fwmark: 1_000_000_000}}},
+		{name: "vless", inbound: &session.Inbound{Name: "vless", User: &protocol.MemoryUser{Fwmark: math.MaxUint32}}, wantMark: math.MaxUint32},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			if test.inbound != nil {
+				ctx = session.ContextWithInbound(ctx, test.inbound)
+			}
+			ctx = contextWithVLESSUserFwmark(ctx)
+			if got := session.OutboundSocketMarkFromContext(ctx); got != test.wantMark {
+				t.Fatalf("mark = %d, want %d", got, test.wantMark)
+			}
+		})
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -73,6 +73,12 @@ type Outbound interface {
 	Process(context.Context, *transport.Link, internet.Dialer) error
 }
 
+// OutboundContextPreparer lets an outbound derive immutable per-flow context
+// before the outbound handler selects a direct or multiplexed dispatch path.
+type OutboundContextPreparer interface {
+	PrepareOutboundContext(context.Context) context.Context
+}
+
 // UserManager is the interface for Inbounds and Outbounds that can manage their users.
 type UserManager interface {
 	// AddUser adds a new user.

--- a/proxy/vless/user_fwmark.go
+++ b/proxy/vless/user_fwmark.go
@@ -1,0 +1,12 @@
+package vless
+
+import "github.com/xtls/xray-core/common/errors"
+
+const MinUserFwmark uint32 = 1_000_000_000
+
+func ValidateUserFwmark(mark uint32) error {
+	if mark != 0 && mark < MinUserFwmark {
+		return errors.New("VLESS user fwmark must be zero or at least ", MinUserFwmark).AtError()
+	}
+	return nil
+}

--- a/proxy/vless/user_fwmark_test.go
+++ b/proxy/vless/user_fwmark_test.go
@@ -1,0 +1,65 @@
+package vless
+
+import (
+	"math"
+	"testing"
+
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/serial"
+	"github.com/xtls/xray-core/common/uuid"
+)
+
+func TestValidateUserFwmark(t *testing.T) {
+	tests := []struct {
+		name    string
+		mark    uint32
+		wantErr bool
+	}{
+		{name: "disabled", mark: 0},
+		{name: "below range", mark: 999_999_999, wantErr: true},
+		{name: "minimum", mark: 1_000_000_000},
+		{name: "maximum", mark: math.MaxUint32},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateUserFwmark(test.mark)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("ValidateUserFwmark(%d) error = %v, wantErr %v", test.mark, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestMemoryValidatorRejectsInvalidFwmarkWithoutMutation(t *testing.T) {
+	id := uuid.New()
+	user := &protocol.MemoryUser{
+		Account: &MemoryAccount{ID: protocol.NewID(id)},
+		Email:   "invalid-fwmark@example.com",
+		Fwmark:  999_999_999,
+	}
+	validator := new(MemoryValidator)
+	if err := validator.Add(user); err == nil {
+		t.Fatal("invalid fwmark unexpectedly accepted")
+	}
+	if validator.GetCount() != 0 || validator.GetByEmail(user.Email) != nil || validator.Get(id) != nil {
+		t.Fatal("rejected user mutated the validator")
+	}
+}
+
+func TestUserFwmarkRoundTrip(t *testing.T) {
+	id := uuid.New()
+	original := &protocol.User{
+		Account: serial.ToTypedMessage(&Account{Id: id.String()}),
+		Fwmark:  math.MaxUint32,
+	}
+	memoryUser, err := original.ToMemoryUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if memoryUser.Fwmark != math.MaxUint32 {
+		t.Fatalf("memory fwmark = %d, want %d", memoryUser.Fwmark, uint32(math.MaxUint32))
+	}
+	if got := protocol.ToProtoUser(memoryUser).GetFwmark(); got != math.MaxUint32 {
+		t.Fatalf("protobuf fwmark = %d, want %d", got, uint32(math.MaxUint32))
+	}
+}

--- a/proxy/vless/validator.go
+++ b/proxy/vless/validator.go
@@ -33,6 +33,9 @@ type MemoryValidator struct {
 
 // Add a VLESS user, Email must be empty or unique.
 func (v *MemoryValidator) Add(u *protocol.MemoryUser) error {
+	if err := ValidateUserFwmark(u.Fwmark); err != nil {
+		return err
+	}
 	if u.Email != "" {
 		_, loaded := v.email.LoadOrStore(strings.ToLower(u.Email), u)
 		if loaded {


### PR DESCRIPTION
## What

- Add an optional `fwmark` to VLESS users, including users added through the Handler API.
- Validate `fwmark` as `0` or `1_000_000_000..uint32 max`.
- Carry a non-zero mark through immutable per-connection context to a direct Freedom socket on Linux.
- Bypass shared outbound mux/XUDP for marked connections.

## Behavior

- `fwmark: 0` preserves the existing static/default routing behavior.
- A non-zero mark is best-effort: if `SO_MARK` fails, Xray logs the socket-option error and continues with the connection, as before.
- Non-Linux and non-direct transport configurations continue without the per-user mark.

## Tests

Tests cover config and API round trips, validation, VLESS/Freedom scoping, call-scoped socket settings, concurrent flows, outbound mux bypass, direct UDP, and Linux compilation.
