### PR TITLE
Limit VLESS UUID to one active IP

### DIFF
--- a/proxy/vless/inbound/connection_tracker.go
+++ b/proxy/vless/inbound/connection_tracker.go
@@ -1,0 +1,160 @@
+package inbound
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"sync"
+
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/proxy/vless"
+)
+
+var (
+	errConnectionTrackerClosed = errors.New("connection tracker is closed")
+	errInvalidConnectionSource = errors.New("connection source is not an ip address")
+)
+
+type resettableConnection interface {
+	SetLinger(int) error
+	Close() error
+}
+
+type connectionTracker struct {
+	mu               sync.Mutex
+	users            map[[16]byte]*activeConnections
+	nextGeneration   uint64
+	nextConnectionID uint64
+	isClosed         bool
+}
+
+type activeConnections struct {
+	ip          netip.Addr
+	generation  uint64
+	connections map[uint64]resettableConnection
+}
+
+func newConnectionTracker() *connectionTracker {
+	return &connectionTracker{
+		users: make(map[[16]byte]*activeConnections),
+	}
+}
+
+func normalizeSourceIP(address net.Address) (netip.Addr, bool) {
+	if address == nil || !address.Family().IsIP() {
+		return netip.Addr{}, false
+	}
+
+	ip, ok := netip.AddrFromSlice(address.IP())
+	if !ok {
+		return netip.Addr{}, false
+	}
+	return ip.Unmap(), true
+}
+
+func (h *Handler) registerAuthenticatedConnection(
+	account *vless.MemoryAccount,
+	source net.Address,
+	connection resettableConnection,
+) (func(), []error, error) {
+	ip, ok := normalizeSourceIP(source)
+	if !ok {
+		return nil, nil, errInvalidConnectionSource
+	}
+
+	return h.connectionTracker.register(
+		vless.ProcessUUID(account.ID.UUID()),
+		ip,
+		connection,
+	)
+}
+
+func (t *connectionTracker) register(
+	userID [16]byte,
+	ip netip.Addr,
+	connection resettableConnection,
+) (func(), []error, error) {
+	t.mu.Lock()
+	if t.isClosed {
+		t.mu.Unlock()
+		return nil, nil, errConnectionTrackerClosed
+	}
+
+	active := t.users[userID]
+	evicted := make([]resettableConnection, 0)
+	if active == nil || active.ip != ip {
+		if active != nil {
+			evicted = make([]resettableConnection, 0, len(active.connections))
+			for _, oldConnection := range active.connections {
+				evicted = append(evicted, oldConnection)
+			}
+		}
+
+		t.nextGeneration++
+		active = &activeConnections{
+			ip:          ip,
+			generation:  t.nextGeneration,
+			connections: make(map[uint64]resettableConnection),
+		}
+		t.users[userID] = active
+	}
+
+	t.nextConnectionID++
+	connectionID := t.nextConnectionID
+	generation := active.generation
+	active.connections[connectionID] = connection
+	t.mu.Unlock()
+
+	release := func() {
+		t.release(userID, generation, connectionID)
+	}
+	return release, resetConnections(evicted), nil
+}
+
+func (t *connectionTracker) release(userID [16]byte, generation, connectionID uint64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	active := t.users[userID]
+	if active == nil || active.generation != generation {
+		return
+	}
+
+	delete(active.connections, connectionID)
+	if len(active.connections) == 0 {
+		delete(t.users, userID)
+	}
+}
+
+func (t *connectionTracker) close() []error {
+	t.mu.Lock()
+	if t.isClosed {
+		t.mu.Unlock()
+		return nil
+	}
+	t.isClosed = true
+
+	connections := make([]resettableConnection, 0)
+	for _, active := range t.users {
+		for _, connection := range active.connections {
+			connections = append(connections, connection)
+		}
+	}
+	clear(t.users)
+	t.mu.Unlock()
+
+	return resetConnections(connections)
+}
+
+func resetConnections(connections []resettableConnection) []error {
+	resetErrs := make([]error, 0)
+	for _, connection := range connections {
+		if err := connection.SetLinger(0); err != nil {
+			resetErrs = append(resetErrs, fmt.Errorf("setting linger to zero: %w", err))
+		}
+		if err := connection.Close(); err != nil {
+			resetErrs = append(resetErrs, fmt.Errorf("closing connection: %w", err))
+		}
+	}
+	return resetErrs
+}

--- a/proxy/vless/inbound/connection_tracker_integration_test.go
+++ b/proxy/vless/inbound/connection_tracker_integration_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package inbound
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/netip"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestConnectionTracker_TCPReset(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("requires Linux loopback and TCP reset semantics")
+	}
+
+	listener, err := net.ListenTCP("tcp4", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	oldClient, oldServer := dialTCPPair(t, listener, "127.0.0.2")
+	defer oldClient.Close()
+	defer oldServer.Close()
+	currentClient, currentServer := dialTCPPair(t, listener, "127.0.0.3")
+	defer currentClient.Close()
+	defer currentServer.Close()
+
+	tracker := newConnectionTracker()
+	userID := [16]byte{1}
+	releaseOld, resetErrs, err := tracker.register(
+		userID,
+		netip.MustParseAddr("127.0.0.2"),
+		oldServer,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resetErrs) != 0 {
+		t.Fatalf("registering old connection: %v", resetErrs)
+	}
+	defer releaseOld()
+
+	if _, err := oldClient.Write([]byte("unread")); err != nil {
+		t.Fatal(err)
+	}
+	releaseCurrent, resetErrs, err := tracker.register(
+		userID,
+		netip.MustParseAddr("127.0.0.3"),
+		currentServer,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resetErrs) != 0 {
+		t.Fatalf("registering current connection: %v", resetErrs)
+	}
+	defer releaseCurrent()
+
+	if err := oldClient.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := oldClient.Read(make([]byte, 1)); !errors.Is(err, syscall.ECONNRESET) {
+		t.Fatalf("reading reset connection: got %v, want %v", err, syscall.ECONNRESET)
+	}
+
+	if err := currentClient.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := currentServer.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := currentClient.Write([]byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+	request := make([]byte, 4)
+	if _, err := io.ReadFull(currentServer, request); err != nil {
+		t.Fatal(err)
+	}
+	if string(request) != "ping" {
+		t.Fatalf("request: got %q, want %q", request, "ping")
+	}
+	if _, err := currentServer.Write([]byte("pong")); err != nil {
+		t.Fatal(err)
+	}
+	response := make([]byte, 4)
+	if _, err := io.ReadFull(currentClient, response); err != nil {
+		t.Fatal(err)
+	}
+	if string(response) != "pong" {
+		t.Fatalf("response: got %q, want %q", response, "pong")
+	}
+}
+
+func dialTCPPair(t *testing.T, listener *net.TCPListener, sourceIP string) (*net.TCPConn, *net.TCPConn) {
+	t.Helper()
+
+	type acceptResult struct {
+		connection *net.TCPConn
+		err        error
+	}
+	accepted := make(chan acceptResult, 1)
+	go func() {
+		connection, err := listener.AcceptTCP()
+		accepted <- acceptResult{connection: connection, err: err}
+	}()
+
+	client, err := net.DialTCP(
+		"tcp4",
+		&net.TCPAddr{IP: net.ParseIP(sourceIP)},
+		listener.Addr().(*net.TCPAddr),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := <-accepted
+	if result.err != nil {
+		client.Close()
+		t.Fatal(result.err)
+	}
+	return client, result.connection
+}

--- a/proxy/vless/inbound/connection_tracker_test.go
+++ b/proxy/vless/inbound/connection_tracker_test.go
@@ -1,0 +1,454 @@
+package inbound
+
+import (
+	"errors"
+	stdnet "net"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/uuid"
+	"github.com/xtls/xray-core/proxy/vless"
+)
+
+type testResettableConnection struct {
+	mu           sync.Mutex
+	lingerValues []int
+	closeCount   int
+	setLingerErr error
+	closeErr     error
+	onSetLinger  func()
+}
+
+func (c *testResettableConnection) SetLinger(seconds int) error {
+	c.mu.Lock()
+	c.lingerValues = append(c.lingerValues, seconds)
+	onSetLinger := c.onSetLinger
+	err := c.setLingerErr
+	c.mu.Unlock()
+
+	if onSetLinger != nil {
+		onSetLinger()
+	}
+	return err
+}
+
+func (c *testResettableConnection) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closeCount++
+	return c.closeErr
+}
+
+func (c *testResettableConnection) resetState() ([]int, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	lingerValues := append([]int{}, c.lingerValues...)
+	return lingerValues, c.closeCount
+}
+
+func TestConnectionTracker_SameIPKeepsConnections(t *testing.T) {
+	tracker := newConnectionTracker()
+	userID := [16]byte{1}
+	ip := netip.MustParseAddr("192.0.2.1")
+	first := &testResettableConnection{}
+	second := &testResettableConnection{}
+
+	releaseFirst, resetErrs, err := tracker.register(userID, ip, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseFirst()
+	if len(resetErrs) != 0 {
+		t.Fatalf("first registration returned reset errors: %v", resetErrs)
+	}
+
+	releaseSecond, resetErrs, err := tracker.register(userID, ip, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseSecond()
+	if len(resetErrs) != 0 {
+		t.Fatalf("same-ip registration returned reset errors: %v", resetErrs)
+	}
+
+	assertNotReset(t, first)
+	assertNotReset(t, second)
+
+	if closeErrs := tracker.close(); len(closeErrs) != 0 {
+		t.Fatalf("closing tracker: %v", closeErrs)
+	}
+	assertReset(t, first)
+	assertReset(t, second)
+}
+
+func TestConnectionTracker_NewIPResetsPreviousConnections(t *testing.T) {
+	tracker := newConnectionTracker()
+	userID := [16]byte{2}
+	oldIP := netip.MustParseAddr("192.0.2.1")
+	newIP := netip.MustParseAddr("192.0.2.2")
+	oldFirst := &testResettableConnection{}
+	oldSecond := &testResettableConnection{}
+	current := &testResettableConnection{}
+
+	releaseOldFirst := mustRegister(t, tracker, userID, oldIP, oldFirst)
+	defer releaseOldFirst()
+	releaseOldSecond := mustRegister(t, tracker, userID, oldIP, oldSecond)
+	defer releaseOldSecond()
+	releaseCurrent := mustRegister(t, tracker, userID, newIP, current)
+	defer releaseCurrent()
+
+	assertReset(t, oldFirst)
+	assertReset(t, oldSecond)
+	assertNotReset(t, current)
+}
+
+func TestConnectionTracker_DifferentUUIDIsUnaffected(t *testing.T) {
+	tracker := newConnectionTracker()
+	firstUser := [16]byte{3}
+	secondUser := [16]byte{4}
+	oldIP := netip.MustParseAddr("192.0.2.1")
+	newIP := netip.MustParseAddr("192.0.2.2")
+	firstUserOld := &testResettableConnection{}
+	firstUserCurrent := &testResettableConnection{}
+	secondUserConnection := &testResettableConnection{}
+
+	defer mustRegister(t, tracker, firstUser, oldIP, firstUserOld)()
+	defer mustRegister(t, tracker, secondUser, oldIP, secondUserConnection)()
+	defer mustRegister(t, tracker, firstUser, newIP, firstUserCurrent)()
+
+	assertReset(t, firstUserOld)
+	assertNotReset(t, firstUserCurrent)
+	assertNotReset(t, secondUserConnection)
+}
+
+func TestConnectionTracker_StaleReleaseCannotRemoveCurrentGeneration(t *testing.T) {
+	tracker := newConnectionTracker()
+	userID := [16]byte{5}
+	oldIP := netip.MustParseAddr("192.0.2.1")
+	currentIP := netip.MustParseAddr("192.0.2.2")
+	old := &testResettableConnection{}
+	currentFirst := &testResettableConnection{}
+	currentSecond := &testResettableConnection{}
+
+	releaseOld := mustRegister(t, tracker, userID, oldIP, old)
+	releaseCurrentFirst := mustRegister(t, tracker, userID, currentIP, currentFirst)
+	releaseOld()
+	releaseCurrentSecond := mustRegister(t, tracker, userID, currentIP, currentSecond)
+
+	assertNotReset(t, currentFirst)
+	assertNotReset(t, currentSecond)
+	if closeErrs := tracker.close(); len(closeErrs) != 0 {
+		t.Fatalf("closing tracker: %v", closeErrs)
+	}
+	assertReset(t, currentFirst)
+	assertReset(t, currentSecond)
+
+	releaseCurrentFirst()
+	releaseCurrentSecond()
+}
+
+func TestConnectionTracker_ResetRunsOutsideMutex(t *testing.T) {
+	tracker := newConnectionTracker()
+	userID := [16]byte{6}
+	oldIP := netip.MustParseAddr("192.0.2.1")
+	newIP := netip.MustParseAddr("192.0.2.2")
+	old := &testResettableConnection{}
+	releaseOld := mustRegister(t, tracker, userID, oldIP, old)
+	old.onSetLinger = releaseOld
+
+	done := make(chan error, 1)
+	go func() {
+		_, resetErrs, err := tracker.register(userID, newIP, &testResettableConnection{})
+		if err == nil && len(resetErrs) != 0 {
+			err = errors.Join(resetErrs...)
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("registration deadlocked while resetting the previous connection")
+	}
+	if closeErrs := tracker.close(); len(closeErrs) != 0 {
+		t.Fatalf("closing tracker: %v", closeErrs)
+	}
+}
+
+func TestConnectionTracker_CloseResetsConnectionsAndRejectsRegistration(t *testing.T) {
+	tracker := newConnectionTracker()
+	userID := [16]byte{7}
+	ip := netip.MustParseAddr("192.0.2.1")
+	connection := &testResettableConnection{}
+
+	release := mustRegister(t, tracker, userID, ip, connection)
+	if closeErrs := tracker.close(); len(closeErrs) != 0 {
+		t.Fatalf("closing tracker: %v", closeErrs)
+	}
+	assertReset(t, connection)
+	release()
+
+	releaseAfterClose, resetErrs, err := tracker.register(
+		userID,
+		ip,
+		&testResettableConnection{},
+	)
+	if !errors.Is(err, errConnectionTrackerClosed) {
+		t.Fatalf("registering after close: got %v, want %v", err, errConnectionTrackerClosed)
+	}
+	if releaseAfterClose != nil {
+		t.Fatal("registration after close returned a release function")
+	}
+	if len(resetErrs) != 0 {
+		t.Fatalf("registration after close returned reset errors: %v", resetErrs)
+	}
+}
+
+func TestConnectionTracker_ResetErrorsDoNotRejectNewConnection(t *testing.T) {
+	tracker := newConnectionTracker()
+	userID := [16]byte{8}
+	oldIP := netip.MustParseAddr("192.0.2.1")
+	newIP := netip.MustParseAddr("192.0.2.2")
+	old := &testResettableConnection{
+		setLingerErr: errors.New("linger failed"),
+		closeErr:     errors.New("close failed"),
+	}
+	current := &testResettableConnection{}
+
+	defer mustRegister(t, tracker, userID, oldIP, old)()
+	releaseCurrent, resetErrs, err := tracker.register(userID, newIP, current)
+	if err != nil {
+		t.Fatalf("registering winner: %v", err)
+	}
+	defer releaseCurrent()
+	if len(resetErrs) != 2 {
+		t.Fatalf("reset error count: got %d, want 2", len(resetErrs))
+	}
+	assertNotReset(t, current)
+}
+
+func TestConnectionTracker_ConcurrentDifferentIPsHaveOneWinner(t *testing.T) {
+	const iterations = 100
+	for range iterations {
+		tracker := newConnectionTracker()
+		userID := [16]byte{9}
+		connections := []*testResettableConnection{{}, {}}
+		ips := []netip.Addr{
+			netip.MustParseAddr("192.0.2.1"),
+			netip.MustParseAddr("192.0.2.2"),
+		}
+		start := make(chan struct{})
+		type result struct {
+			release   func()
+			resetErrs []error
+			err       error
+		}
+		results := make(chan result, len(connections))
+		releases := make([]func(), 0, len(connections))
+
+		var waitGroup sync.WaitGroup
+		for index := range connections {
+			waitGroup.Add(1)
+			go func() {
+				defer waitGroup.Done()
+				<-start
+				release, resetErrs, err := tracker.register(
+					userID,
+					ips[index],
+					connections[index],
+				)
+				results <- result{release: release, resetErrs: resetErrs, err: err}
+			}()
+		}
+		close(start)
+		waitGroup.Wait()
+		close(results)
+
+		for result := range results {
+			if result.err != nil {
+				t.Fatal(result.err)
+			}
+			if len(result.resetErrs) != 0 {
+				t.Fatalf("registration returned reset errors: %v", result.resetErrs)
+			}
+			releases = append(releases, result.release)
+		}
+
+		resetCount := 0
+		for _, connection := range connections {
+			_, closeCount := connection.resetState()
+			if closeCount == 1 {
+				resetCount++
+			}
+		}
+		if resetCount != 1 {
+			t.Fatalf("reset connection count: got %d, want 1", resetCount)
+		}
+		for _, release := range releases {
+			release()
+		}
+	}
+}
+
+func TestNormalizeSourceIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		address  net.Address
+		expected netip.Addr
+		isValid  bool
+	}{
+		{
+			name:     "ipv4",
+			address:  net.IPAddress([]byte{192, 0, 2, 1}),
+			expected: netip.MustParseAddr("192.0.2.1"),
+			isValid:  true,
+		},
+		{
+			name:     "ipv6",
+			address:  net.IPAddress(stdnet.ParseIP("2001:db8::1")),
+			expected: netip.MustParseAddr("2001:db8::1"),
+			isValid:  true,
+		},
+		{
+			name: "ipv4-mapped ipv6",
+			address: testIPAddress{
+				ip:     stdnet.ParseIP("::ffff:192.0.2.1"),
+				family: net.AddressFamilyIPv6,
+			},
+			expected: netip.MustParseAddr("192.0.2.1"),
+			isValid:  true,
+		},
+		{
+			name:    "domain",
+			address: net.DomainAddress("example.com"),
+			isValid: false,
+		},
+		{
+			name:    "missing address",
+			address: nil,
+			isValid: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, ok := normalizeSourceIP(test.address)
+			if ok != test.isValid {
+				t.Fatalf("validity: got %v, want %v", ok, test.isValid)
+			}
+			if actual != test.expected {
+				t.Fatalf("address: got %v, want %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestHandler_RegisterAuthenticatedConnectionUsesCanonicalUUID(t *testing.T) {
+	handler := &Handler{connectionTracker: newConnectionTracker()}
+	firstUUID := uuid.UUID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	secondUUID := firstUUID
+	secondUUID[6] = 99
+	secondUUID[7] = 100
+	firstAccount := &vless.MemoryAccount{ID: protocol.NewID(firstUUID)}
+	secondAccount := &vless.MemoryAccount{ID: protocol.NewID(secondUUID)}
+	oldConnection := &testResettableConnection{}
+	currentConnection := &testResettableConnection{}
+
+	releaseOld, resetErrs, err := handler.registerAuthenticatedConnection(
+		firstAccount,
+		net.IPAddress([]byte{192, 0, 2, 1}),
+		oldConnection,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resetErrs) != 0 {
+		t.Fatalf("first registration returned reset errors: %v", resetErrs)
+	}
+	defer releaseOld()
+
+	releaseCurrent, resetErrs, err := handler.registerAuthenticatedConnection(
+		secondAccount,
+		net.IPAddress([]byte{192, 0, 2, 2}),
+		currentConnection,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resetErrs) != 0 {
+		t.Fatalf("second registration returned reset errors: %v", resetErrs)
+	}
+	defer releaseCurrent()
+
+	assertReset(t, oldConnection)
+	assertNotReset(t, currentConnection)
+}
+
+type testIPAddress struct {
+	ip     stdnet.IP
+	family net.AddressFamily
+}
+
+func (a testIPAddress) IP() stdnet.IP {
+	return a.ip
+}
+
+func (testIPAddress) Domain() string {
+	return ""
+}
+
+func (a testIPAddress) Family() net.AddressFamily {
+	return a.family
+}
+
+func (a testIPAddress) String() string {
+	return a.ip.String()
+}
+
+func mustRegister(
+	t *testing.T,
+	tracker *connectionTracker,
+	userID [16]byte,
+	ip netip.Addr,
+	connection resettableConnection,
+) func() {
+	t.Helper()
+	release, resetErrs, err := tracker.register(userID, ip, connection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resetErrs) != 0 {
+		t.Fatalf("registration returned reset errors: %v", resetErrs)
+	}
+	return release
+}
+
+func assertReset(t *testing.T, connection *testResettableConnection) {
+	t.Helper()
+	lingerValues, closeCount := connection.resetState()
+	if len(lingerValues) != 1 || lingerValues[0] != 0 {
+		t.Fatalf("linger values: got %v, want [0]", lingerValues)
+	}
+	if closeCount != 1 {
+		t.Fatalf("close count: got %d, want 1", closeCount)
+	}
+}
+
+func assertNotReset(t *testing.T, connection *testResettableConnection) {
+	t.Helper()
+	lingerValues, closeCount := connection.resetState()
+	if len(lingerValues) != 0 {
+		t.Fatalf("linger values: got %v, want none", lingerValues)
+	}
+	if closeCount != 0 {
+		t.Fatalf("close count: got %d, want 0", closeCount)
+	}
+}

--- a/proxy/vless/inbound/inbound.go
+++ b/proxy/vless/inbound/inbound.go
@@ -89,6 +89,7 @@ type Handler struct {
 	defaultDispatcher      routing.Dispatcher
 	ctx                    context.Context
 	fallbacks              map[string]map[string]map[string]*Fallback // or nil
+	connectionTracker      *connectionTracker
 	clientConnections      map[net.Conn]struct{}
 	notifiedInvalidIDs     map[string]time.Time
 	clientMutex            sync.Mutex
@@ -109,6 +110,7 @@ func New(ctx context.Context, config *Config, dc dns.Client, validator vless.Val
 		observer:               v.GetFeature(extension.ObservatoryType()),
 		defaultDispatcher:      v.GetFeature(routing.DispatcherType()).(routing.Dispatcher),
 		ctx:                    ctx,
+		connectionTracker:      newConnectionTracker(),
 		clientConnections:      make(map[net.Conn]struct{}),
 		notifiedInvalidIDs:     make(map[string]time.Time),
 	}
@@ -259,6 +261,10 @@ func (h *Handler) RemoveReverse(u *protocol.MemoryUser) {
 
 // Close implements common.Closable.Close().
 func (h *Handler) Close() error {
+	var closeErrs []error
+	if h.connectionTracker != nil {
+		closeErrs = append(closeErrs, h.connectionTracker.close()...)
+	}
 	if h.decryption != nil {
 		h.decryption.Close()
 	}
@@ -266,7 +272,6 @@ func (h *Handler) Close() error {
 		h.RemoveReverse(u)
 	}
 	h.clientMutex.Lock()
-	var closeErrs []error
 	for clientConn := range h.clientConnections {
 		closeErrs = append(closeErrs, clientConn.Close())
 	}
@@ -640,6 +645,23 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 		}
 	default:
 		return errors.New("unknown request flow " + requestAddons.Flow).AtWarning()
+	}
+
+	rawConnection, _, _ := proxy.UnwrapRawConn(connection)
+	tcpConnection, ok := rawConnection.(*net.TCPConn)
+	if ok {
+		releaseConnection, resetErrs, err := h.registerAuthenticatedConnection(
+			account,
+			inbound.Source.Address,
+			tcpConnection,
+		)
+		if err != nil {
+			return errors.New("failed to track vless connection").Base(err).AtWarning()
+		}
+		defer releaseConnection()
+		for _, resetErr := range resetErrs {
+			errors.LogWarningInner(ctx, resetErr, "failed to reset previous vless connection")
+		}
 	}
 
 	if request.Command != protocol.RequestCommandMux {


### PR DESCRIPTION
A VLESS UUID can now stay active from one IP at a time.

When the same UUID connects from a new IP, existing TCP connections from the previous IP are reset. Multiple connections from the same IP keep working.

Tested with VLESS TCP/REALITY and a Linux TCP RST integration test.